### PR TITLE
docs(installation): fixed the command to download md-book because it …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ MD-Book is the next-generation documentation generator for Rust projects. Built 
 
 ### Installation
 ```bash
-cargo install md-book
+cargo install --git https://github.com/terraphim/md-book.git
 ```
 
 ### Basic Usage


### PR DESCRIPTION
# fix command to download md-book with `cargo`

```sh
$ cargo install md-book
Found existing alias for "cargo". You should use: "cg"
    Updating crates.io index
error: could not find `md-book` in registry `crates-io` with version `*`
```