### PR TITLE
Fix #1: Decompose build pipeline into collect/preprocess/render/index

### DIFF
--- a/.agent/handoffs/2026-08-08-mdbook-parity-a.md
+++ b/.agent/handoffs/2026-08-08-mdbook-parity-a.md
@@ -1,0 +1,42 @@
+# Handover: mdBook parity Increment A
+
+**Date**: 2026-08-08  
+**UTC end**: see verification report  
+**Change slug**: mdbook-parity-a  
+**Issue**: #1  
+**Branch**: `task/1-pipeline-decomposition`
+
+## Completed
+
+- Decomposed build into `src/pipeline/` + `src/render/`
+- Identity preprocess seam with tests
+- Byte-identical output vs pre-A baseline (72 files)
+- Verification, validation, review artefacts written
+- Unrelated WIP left in `git stash` (message: `wip: unrelated SEO/template/dist changes`)
+
+## Known-good state
+
+- All unit + integration tests listed in verification report pass
+- Clippy clean with `-D warnings`
+
+## Resume steps (next agent)
+
+1. `git checkout task/1-pipeline-decomposition` (or merge PR for #1)
+2. Claim Gitea **#2** (Increment B — SUMMARY.md book model); Phase 2.5 findings already in the plan
+3. Do **not** drop `stash@{0}` without restoring for the user — it holds SEO/template work
+4. B1 starts with structure fixture `tests/fixtures/test_book_mdbook.structure.json`
+
+## Artefacts
+
+- Research: `docs/plans/mdbook-parity-research.md`
+- Design: `docs/plans/mdbook-parity-implementation-plan.md`
+- Session: `.agent/sessions/2026-08-08-mdbook-parity-a.md`
+- Verification: `docs/verification/verification-report-mdbook-parity-a.md`
+- Validation: `docs/validation/validation-report-mdbook-parity-a.md`
+- Review: `docs/plans/review-mdbook-parity-a.md`
+
+## Next actions
+
+1. Open/merge PR for #1  
+2. Start Increment B on `task/2-summary-book-model`  
+3. Restore stash only if resuming SEO WIP separately  

--- a/.agent/sessions/2026-08-08-mdbook-parity-a.md
+++ b/.agent/sessions/2026-08-08-mdbook-parity-a.md
@@ -1,0 +1,38 @@
+# Session Start: mdBook parity Increment A
+
+**Date**: 2026-08-08
+**UTC Start**: 09:52:25 UTC
+**Change Slug**: mdbook-parity-a
+**Branch**: task/1-pipeline-decomposition
+**Scope**: Increment A — decompose build pipeline into collect/preprocess/render/index
+**Linked Issue**: https://git.terraphim.cloud/terraphim/md-book/issues/1
+
+## Repository Context
+- Current branch: task/1-pipeline-decomposition (from main @ 82de35d)
+- Recent commits: docs for parity research/plan/spec findings
+- Working tree: clean for A; unrelated SEO/template WIP stashed as stash@{0}
+- Relevant artefacts: docs/plans/mdbook-parity-{research,implementation-plan}.md
+
+## Planned Artifact Chain
+- Research: docs/plans/mdbook-parity-research.md (done)
+- Design: docs/plans/mdbook-parity-implementation-plan.md (done, approved)
+- Spec: Phase 2.5 findings for B appended to plan (A has no separate spec)
+- Verification: docs/verification/verification-report-mdbook-parity-a.md
+- Validation: docs/validation/validation-report-mdbook-parity-a.md
+- Review: docs/plans/review-mdbook-parity-a.md
+- Handover: .agent/handoffs/2026-08-08-mdbook-parity-a.md
+
+## Subtasks
+1. [M] A1 Extract stages into pipeline/ + render/
+2. [S] A2 Preprocess identity seam
+3. [S] A3 Baseline benchmark / byte-identical gate
+4. [S] Verification + PR
+
+## Risks and Blockers
+- Zoned::now() year in templates may affect byte compare across year boundary only
+- Pagefind index may be non-deterministic; compare HTML excluding pagefind/
+- Unrelated WIP stashed — do not drop stash
+
+## Notes
+- Research/design already approved; skip re-research
+- Zero behaviour change is the gate

--- a/docs/plans/mdbook-parity-implementation-plan.md
+++ b/docs/plans/mdbook-parity-implementation-plan.md
@@ -271,17 +271,31 @@ pub struct Chapter {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SectionNumber(pub Vec<u32>);
 
-/// One entry of the pre-flattened sidebar list handed to Tera
-/// (Tera has no template recursion, so nesting is expressed as `depth`).
+/// One entry of the pre-flattened sidebar list handed to Tera.
+///
+/// Tera macros cannot recurse, so the tree is flattened and nesting is
+/// reconstructed by the template from the `open_lists` / `close_lists` deltas.
+/// This yields genuinely nested `<ul>` markup (required by the accessibility
+/// decision in the interview findings) from a single template loop.
 #[derive(Debug, Clone, Serialize)]
 pub struct NavEntry {
     pub kind: NavKind,          // Chapter | PartTitle | Separator
-    pub title: String,
-    /// Root-relative href; `None` for drafts, part titles and separators.
+    /// Sidebar label: the SUMMARY link text, inline markdown rendered.
+    pub title_html: String,
+    /// Same label flattened to plain text, for `<title>` and `aria-label`.
+    pub title_text: String,
+    /// Href relative to the current page; `None` for drafts, part titles and
+    /// separators. External SUMMARY links carry their absolute URL here.
     pub href: Option<String>,
+    /// True when `href` points off-site (rendered with `rel="external"`).
+    pub is_external: bool,
     /// Rendered section number, e.g. "1.2."; empty when `no-section-label` is set.
     pub number: String,
     pub depth: usize,
+    /// `<ul>` elements to open before emitting this entry (0 or 1).
+    pub open_lists: usize,
+    /// `</ul></li>` pairs to close before emitting this entry.
+    pub close_lists: usize,
     pub is_draft: bool,
     pub is_active: bool,
 }
@@ -294,23 +308,34 @@ pub struct NavEntry {
 
 /// Parse the contents of a `SUMMARY.md`.
 ///
+/// Parsing does not stop at the first problem: the whole file is scanned and
+/// every error collected, so one build round-trip reports everything wrong.
+///
 /// # Errors
-/// - `SummaryError::MixedDelimiters` -- `-` and `*` both used for list items.
-/// - `SummaryError::PrefixAfterNumbered` -- a prefix chapter follows numbered chapters.
-/// - `SummaryError::Malformed` -- a list item that is not a link.
-pub fn parse_summary(content: &str) -> Result<Summary, SummaryError>;
+/// Returns every problem found, each carrying a line number and the offending
+/// text: `MixedDelimiters`, `PrefixAfterNumbered`, `Malformed`,
+/// `DuplicateEntry`, `NonMarkdownTarget`.
+pub fn parse_summary(content: &str) -> Result<Summary, SummaryErrors>;
 
 /// Build a `Book` from a summary, resolving paths against `src_dir` and
 /// assigning section numbers.
 ///
+/// Path resolution is containment-checked: every chapter path is canonicalised
+/// (resolving symlinks) and must remain under `src_dir`.
+///
+/// When `create_missing` is true (the default), a referenced file that does not
+/// exist is created as a stub containing a single H1 taken from the SUMMARY link
+/// text; an existing file is never overwritten. Created paths are returned so the
+/// watcher can suppress the resulting filesystem events.
+///
 /// # Errors
-/// Returns `SummaryError::MissingFile` when a referenced file is absent and
-/// `build.create-missing` is false.
+/// `EscapesSourceDir` for any path resolving outside `src_dir`; `MissingFile`
+/// when the file is absent and `create_missing` is false.
 pub fn book_from_summary(
     summary: &Summary,
     src_dir: &Path,
     create_missing: bool,
-) -> Result<Book, SummaryError>;
+) -> Result<(Book, Vec<PathBuf>), SummaryErrors>;
 
 // src/book/directory.rs
 
@@ -369,12 +394,27 @@ pub enum SummaryError {
     #[error("SUMMARY.md line {line}: expected a markdown link, found: {text}")]
     Malformed { line: usize, text: String },
 
+    #[error("SUMMARY.md line {line}: '{path}' is already listed (line {first_line})")]
+    DuplicateEntry { line: usize, path: PathBuf, first_line: usize },
+
+    #[error("SUMMARY.md line {line}: chapter target must be a .md file, found: {path}")]
+    NonMarkdownTarget { line: usize, path: PathBuf },
+
+    #[error("SUMMARY.md line {line}: '{path}' resolves outside the source directory; \
+             refusing to read")]
+    EscapesSourceDir { line: usize, path: PathBuf },
+
     #[error("SUMMARY.md references missing file: {path}")]
     MissingFile { path: PathBuf },
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
+
+/// Every problem found in one pass, reported together before aborting.
+#[derive(Debug, thiserror::Error)]
+#[error("SUMMARY.md has {} problem(s)", .0.len())]
+pub struct SummaryErrors(pub Vec<SummaryError>);
 ```
 
 ## Test strategy
@@ -391,6 +431,15 @@ No mocks (project rule). Every test builds real books from real fixtures.
 | `test_parse_draft_chapter` | `book/summary.rs` | `- [Title]()` → `source_path: None` |
 | `test_parse_rejects_mixed_delimiters` | `book/summary.rs` | `MixedDelimiters` |
 | `test_parse_rejects_prefix_after_numbered` | `book/summary.rs` | `PrefixAfterNumbered` |
+| `test_parse_collects_all_errors_in_one_pass` | `book/summary.rs` | Three seeded problems → three errors, in line order |
+| `test_parse_rejects_duplicate_entry` | `book/summary.rs` | `DuplicateEntry` names both lines |
+| `test_parse_rejects_non_markdown_target` | `book/summary.rs` | `NonMarkdownTarget` |
+| `test_parse_accepts_anchor_link` | `book/summary.rs` | Fragment stripped for resolution, kept on href |
+| `test_parse_accepts_external_url` | `book/summary.rs` | `is_external`, no output path, no chain slot |
+| `test_summary_rejects_paths_escaping_src` | `book/summary.rs` | `../`, absolute, and a symlink out of `src/` |
+| `test_create_missing_writes_stub_once` | `book/summary.rs` | Stub H1 from link text; existing file never overwritten; created paths returned |
+| `test_to_nav_list_deltas_balance` | `book/mod.rs` | Σ`open_lists` == Σ`close_lists` for any tree |
+| `test_title_from_summary_not_h1` | `book/mod.rs` | Link text wins; markdown rendered for HTML, flattened for `<title>` |
 | `test_section_numbering_matches_nesting` | `book/mod.rs` | `1`, `1.1`, `1.1.1`, `2` |
 | `test_prefix_suffix_draft_are_unnumbered` | `book/mod.rs` | `number: None` |
 | `test_readme_maps_to_index_html` | `book/mod.rs` | `README.md` → `index.html` |
@@ -407,7 +456,10 @@ No mocks (project rule). Every test builds real books from real fixtures.
 | Test | Location | Purpose |
 |------|----------|---------|
 | `test_structure_matches_fixture` | `tests/integration/structure_test.rs` | Built tree vs `test_book_mdbook.structure.json` |
-| `test_files_absent_from_summary_not_published` | same | Summary-driven exclusion |
+| `test_files_absent_from_summary_not_published` | same | Summary-driven exclusion; orphan `.md` warns |
+| `test_non_markdown_assets_copied_through` | same | `src/img/*.png` reaches the build dir at the same relative path |
+| `test_watch_suppresses_created_stub_event` | same | `create-missing` under `--watch` does not trigger a second rebuild |
+| `test_sidebar_nesting_and_aria` | same | Nested `<ul>`, `aria-current="page"`, `aria-disabled` drafts, part-title `<h2>` |
 | `test_prev_next_chain_follows_summary` | same | Walk the whole chain |
 | `test_no_summary_falls_back_to_directory` | same | `tests/assets/test_book_1` unchanged |
 | `test_existing_templates_still_render` | same | Flat `sections` still populated |
@@ -606,7 +658,135 @@ only `is_active`. **Do not do this pre-emptively** -- measure first.
 - [x] Increment sequencing agreed (A → B → C → D → E, F later)
 - [x] Human approval received -- Alex Mikhalev, 2026-08-08
 
-**Next phase:** `disciplined-specification` (Phase 2.5) on increment B before any code is
-written -- the summary parser has the most edge cases (mixed delimiters, missing files,
-`create-missing`, non-UTF-8 paths, duplicate entries, links with anchors or query strings).
-Findings are appended to this document.
+**Next phase:** `disciplined-specification` (Phase 2.5) on increment B -- **complete**, findings
+appended below. Implementation may proceed with increment A.
+
+---
+
+## Specification Interview Findings -- Increment B
+
+**Interview date**: 2026-08-08
+**Dimensions covered**: Failure modes; Edge cases & boundaries; Concurrency; Integration
+effects; Migration & compatibility; Operational concerns; Security; Accessibility; User mental
+models (9 of 10 -- scale & performance was already settled in the plan's benchmark section).
+**Convergence status**: Complete. Round 3 produced one design consequence (nested markup vs the
+flat `NavEntry` list, folded into the API above) and otherwise confirmed the recommended
+positions.
+
+### Key decisions from interview
+
+#### Failure modes
+
+- **`create-missing` is honoured, defaulting to true** -- matching mdBook. A `SUMMARY.md` entry
+  whose file is absent causes md-book to write a stub into `src/` and build it. Accepted
+  consequence: the build mutates the user's source tree by default. The stub is a single H1
+  derived from the SUMMARY link text; nothing else is written, and an existing file is never
+  overwritten.
+- **Summary syntax errors are collected, not fail-fast.** Parse the whole file, accumulate every
+  problem with line number and offending text, print them together, exit non-zero. Rationale:
+  migrating a large book should take one build round-trip, not one per typo. This changes
+  `parse_summary` from `Result<Summary, SummaryError>` to returning
+  `Result<Summary, Vec<SummaryError>>` (or a `SummaryErrors` collection implementing
+  `Display` over the set) -- **update the API signature accordingly during B2**.
+
+#### Edge cases and boundaries
+
+Accepted SUMMARY link forms:
+
+| Form | Behaviour |
+|------|-----------|
+| `[API](api.md#errors)` | Fragment stripped for file resolution, preserved on the sidebar href. Depends on increment D's server-side heading IDs to actually land. |
+| `[Rust](https://rust-lang.org)` | Sidebar entry linking off-site; no page generated, no slot in the prev/next chain, `rel="external"`. |
+
+Rejected forms -- both join the collected error set and abort the build:
+
+| Form | Rationale |
+|------|-----------|
+| The same file listed twice | Almost always a copy-paste error; the error names both line numbers. |
+| Non-`.md` target, e.g. `[Sample](sample.rs)` | The summary describes a tree of markdown chapters; assets are reached by in-page links, not sidebar entries. |
+
+- **Unlisted files**: non-markdown files under `src/` are copied through to the build directory
+  preserving relative paths (this is how in-book images work). Orphan `.md` files are not
+  published, and each is named in a warning so accidental omissions stay visible.
+
+#### Concurrency
+
+- **`create-missing` under `--watch`/`--serve`**: md-book records the paths it creates and
+  suppresses the next watcher event for each, so a created stub cannot trigger a rebuild. The
+  system converges after a single build because the second parse finds the file present.
+  Implementation note: the suppression set is consumed (not merely checked), so a genuine user
+  edit to that same file immediately afterwards still triggers a rebuild.
+
+#### Security
+
+- **Path containment is enforced.** Every resolved chapter path is canonicalised and must remain
+  under the source directory; `../../private/notes.md` and absolute paths are refused as
+  collected errors. Rationale: a documentation build that reads outside its tree and republishes
+  the contents is an exfiltration path, and `SUMMARY.md` may arrive from an untrusted pull
+  request in CI. Canonicalisation happens after symlink resolution, so a symlink inside `src/`
+  pointing outside it is also refused.
+- New test: `test_summary_rejects_paths_escaping_src`, including the symlink case.
+
+#### User mental models
+
+- **SUMMARY link text wins as the chapter title**, for the sidebar, `<title>`, prev/next labels
+  and numbering. Inline markdown in the link text is rendered in HTML contexts and flattened for
+  `<title>`. The page's own H1 is left untouched. This also fixes today's defect where raw
+  `**bold**` from a heading leaks into the browser tab (`core.rs:388-393`).
+- **Section numbers appear in the sidebar only**, suppressible with `no-section-label`. Page
+  headings, `<title>` and therefore Pagefind's indexed titles stay as the author wrote them --
+  numbering is a navigation aid, not a rewrite of the author's content.
+
+#### Integration effects
+
+- **Previous/next chain** covers every reachable page in authored order -- prefix, then numbered,
+  then suffix. Draft chapters, part titles, separators and external links are skipped rather
+  than becoming dead ends, since none of them has a page.
+
+#### Accessibility
+
+- The sidebar emits genuinely nested `<ul>` markup mirroring the chapter tree; part titles are
+  real `<h2>` elements between lists; separators are `<hr aria-hidden="true">`; the active page
+  carries `aria-current="page"`; draft chapters render as `<span aria-disabled="true">` rather
+  than links, so keyboard users never tab into a dead end. Section numbers sit inside the link
+  text. The whole nav is wrapped in `<nav aria-label="Book navigation">`.
+- **Design consequence**: Tera macros cannot recurse, so nested markup cannot come from a plain
+  depth-tagged list. `NavEntry` gains `open_lists` / `close_lists` deltas (see the API section
+  above) allowing one template loop to emit correct nesting. New test:
+  `test_to_nav_list_deltas_balance` -- the sum of opens equals the sum of closes for any tree.
+
+#### Migration and compatibility
+
+- The deprecated flat `sections` variable is populated as **one section per top-level chapter**,
+  titled after that chapter and containing its descendants flattened. An unmigrated template
+  renders a sensible, if flatter, sidebar. A deprecation warning fires when a custom template
+  directory is in use. Removal target: **0.3.0**.
+
+### Deferred items
+
+| Item | Deferred because |
+|------|------------------|
+| Scale beyond ~1,000 chapters (hoisting `to_nav` out of the page loop) | Measure first; the corpus is 30 pages. Bench added in increment A. |
+| Non-UTF-8 paths in `SUMMARY.md` | Existing code already surfaces these as errors (`core.rs:485-489`); no new behaviour needed. |
+| Per-chapter search enable (`[output.html.search.chapter]`) | Pagefind-side capability question, not a book-model question. |
+
+### Interview summary
+
+Three rounds, four questions each. The interview changed the plan in five substantive ways.
+Two decisions went against the drafted recommendation: `create-missing` is honoured with mdBook's
+default of true (the plan had assumed a non-destructive warn-and-draft), and summary errors are
+collected rather than fail-fast (the plan's error enum implied one error per build). Both are
+recorded in the API section above and must be reflected in B2's signatures before coding starts.
+
+The security dimension surfaced a requirement absent from the plan entirely: path containment.
+`SUMMARY.md` is author-controlled input that names files to read and republish, which in CI can
+mean input from an untrusted pull request. Rejecting anything that canonicalises outside `src/`
+-- symlinks included -- closes that path, and is cheap to enforce at resolution time.
+
+The accessibility decision had the largest design ripple. Committing to genuinely nested `<ul>`
+markup with `aria-current` and disabled draft entries is incompatible with the flat depth-tagged
+`NavEntry` list, because Tera macros cannot recurse. Adding `open_lists`/`close_lists` deltas
+keeps the single-loop template while producing correct hierarchy for screen readers. The
+remaining decisions -- SUMMARY link text as the title source, sidebar-only numbering, the
+prev/next chain skipping page-less items, and asset pass-through with orphan warnings -- all
+confirmed the drafted positions and needed no structural change.

--- a/docs/plans/mdbook-parity-implementation-plan.md
+++ b/docs/plans/mdbook-parity-implementation-plan.md
@@ -1,0 +1,612 @@
+# Implementation Plan: mdBook Feature Parity
+
+**Status**: Approved (2026-08-08)
+**Research Doc**: `docs/plans/mdbook-parity-research.md`
+**Author**: Claude (Opus 5), with Alex Mikhalev
+**Date**: 2026-08-08
+**Estimated Effort**: 11-15 days across five increments
+**Phase**: 2 (disciplined-design)
+
+## Overview
+
+### Summary
+
+Bring md-book to *contract parity* with mdBook: any valid mdBook book builds correctly, rendered
+through md-book's own stack. Five increments, each independently shippable:
+
+| # | Increment | Effort | Ships |
+|---|-----------|--------|-------|
+| A | Pipeline decomposition | 1-1.5 d | No behaviour change; unblocks everything else |
+| B | `SUMMARY.md` book model (P0) | 4-5 d | Correct structure, ordering, navigation |
+| C | CLI subcommands + book-directory resolution | 1.5-2 d | `md-book build ./mybook`, `book.src`, `build.build-dir` |
+| D | Output-correctness defects (P1) | 2-2.5 d | Relocatable, offline, anchorable output |
+| E | Renderer polish (P3) | 2-3 d | Themes, print, redirects, fold, shortcuts |
+
+The `pulldown-cmark` backend (approved as a feature-flagged second parser) is designed here as
+**increment F** and specified at interface level only; it is sequenced after E and gets its own
+implementation cycle.
+
+### Approach
+
+Interpretation B from the research doc: parity of the authored book contract, not of mdBook's
+internals. Introduce an explicit `Book` model between input and rendering, so that structure
+becomes data rather than a side effect of directory traversal.
+
+The current pipeline is one 250-line function (`core.rs:129-386`) that interleaves collection,
+rendering and indexing. Increment A splits it into four named stages; every later increment then
+targets exactly one stage.
+
+### Scope
+
+**In scope:**
+
+- Decompose `build_sync_impl_sync` into `collect` / `preprocess` / `render` / `index`.
+- `SUMMARY.md` parser: prefix/suffix chapters, part titles, nested numbered chapters, draft
+  chapters, separators, section numbering, summary-driven file exclusion.
+- `README.md` → `index.html` mapping.
+- Chapter-tree navigation, correct previous/next, nested sidebar.
+- Directory-walk fallback when no `SUMMARY.md` exists (no existing book breaks).
+- `md-book build|serve|watch|init|clean [dir]` subcommands, with `-i/-o` retained as overrides.
+- `book.src`, `build.build-dir`, `build.extra-watch-dirs`.
+- Relative asset paths (`path_to_root`), vendored Shoelace, server-side heading IDs, 404 page,
+  copy button wired up.
+- Themes (light/dark/ayu/coal/navy toggle), configurable syntect theme, print page,
+  `additional-css` / `additional-js`, `[output.html.redirect]`, `[output.html.fold]`, keyboard
+  shortcuts.
+- Warnings for parsed-but-unsupported config keys.
+- Structural conformance fixtures over `test_book_mdbook/`.
+- Interface-level design for the `pulldown-cmark` backend (increment F).
+
+**Out of scope (deferred to their own cycles):**
+
+- **P2 preprocessing** -- `{{#include}}` (+ line ranges, anchors), `{{#rustdoc_include}}`,
+  `{{#playground}}`, `{{#title}}`, hidden lines, Rust code-block attributes. Increment A leaves
+  a designated seam for it. **Consequence to state plainly: after this plan, an mdBook book
+  containing `{{#include}}` still renders the directive as literal text.**
+- Implementation of the `pulldown-cmark` backend (designed here, built later).
+- `mdbook test` (rustdoc doctests).
+- Preprocessor / alternative-backend plugin protocol.
+
+**Avoid at all cost** (5/25 -- these threaten the essential):
+
+- Handlebars theme compatibility (`index.hbs`, `head.hbs`, `{{#toc}}`, `{{fa}}`).
+- elasticlunr, or emulating its scoring knobs (`boost-*`, `expand`, `use-boolean-and`,
+  `teaser-word-count`) on top of Pagefind.
+- Rust Playground runtime (run button, live editor).
+- `hash-files`, `cname`, `text-direction`, shell `completions`.
+- Byte-for-byte HTML matching with mdBook, or porting mdBook's CSS.
+- A generic "renderer" trait abstraction with one implementation.
+- Making Pagefind a hard build dependency.
+
+## Architecture
+
+### Component diagram
+
+```
+                            ┌──────────────────────────────┐
+  book.toml ───────────────►│ config::resolve_book_paths   │  (increment C)
+  CLI (subcommand + flags)  │  root, src_dir, build_dir    │
+                            └──────────────┬───────────────┘
+                                           ▼
+   src/SUMMARY.md ────►┌───────────────────────────────────┐
+                       │ summary::parse  (increment B)     │
+                       │   -> Summary { prefix, numbered,  │
+                       │                suffix }           │
+                       └──────────────┬────────────────────┘
+                                      │  absent? -> book::from_directory (fallback, today's walk)
+                                      ▼
+                       ┌───────────────────────────────────┐
+                       │ book::Book  { items: Vec<BookItem> }   ← the model everything reads
+                       └──────────────┬────────────────────┘
+                                      ▼
+                       ┌───────────────────────────────────┐
+                       │ preprocess  (increment A: seam)   │  markdown text in -> out
+                       │   today: identity                 │  P2 directives land here
+                       └──────────────┬────────────────────┘
+                                      ▼
+                       ┌───────────────────────────────────┐
+                       │ render::markdown  (F: 2 backends) │
+                       │   mdast splice + syntect          │
+                       │   + heading IDs   (increment D)   │
+                       └──────────────┬────────────────────┘
+                                      ▼
+                       ┌───────────────────────────────────┐
+                       │ render::html   Tera               │
+                       │   nav tree, path_to_root, themes  │  (B, D, E)
+                       └──────────────┬────────────────────┘
+                                      ▼
+                       ┌───────────────────────────────────┐
+                       │ index  Pagefind (unchanged)       │
+                       └───────────────────────────────────┘
+```
+
+### Data flow
+
+```
+resolve paths -> load config -> build Book (SUMMARY or directory walk)
+  -> for each chapter: read md -> preprocess -> parse+highlight -> heading IDs -> link rewrite
+  -> render page (nav tree + path_to_root + prev/next from book order)
+  -> render index / print / 404 / redirects -> copy assets -> pagefind index
+```
+
+### Key design decisions
+
+| Decision | Rationale | Alternatives rejected |
+|----------|-----------|----------------------|
+| Introduce an explicit `Book`/`BookItem` model | Structure becomes data; navigation, numbering, prev/next and exclusion all read one source | Keep deriving structure inside the render loop (today) -- the cause of every A-row gap |
+| `SUMMARY.md` presence *selects* the mode; directory walk is the fallback | No existing book breaks; migration is opt-in by adding a file | Mandatory `SUMMARY.md` (breaks Terraphim docs and `dist/`); config flag (extra knob for a decidable condition) |
+| Keep flat `sections` in the Tera context alongside the new `chapters` tree for one release | User-supplied templates (`paths.templates`) keep working | Hard cutover -- silently breaks overridden sidebars |
+| Pre-flatten the chapter tree into a depth-tagged list for Tera | Tera has no template recursion; a flat list with `depth` renders nested markup with one loop | Tera macro recursion (fragile, poor errors); render nav in Rust (moves markup out of templates) |
+| Subcommands added, `-i/-o` retained as overrides | mdBook users get the familiar entry point; CI, Dockerfile and `scripts/deploy.sh` stay green | Full CLI switch (breaks this repo's workflows in one go); `-i/-o` only (`book.src` unsupportable) |
+| `path_to_root` computed per page; all template asset URLs become relative | Fixes sub-path deployment; matches mdBook | Configurable `site-url` prefix only -- still absolute, still breaks local `file://` viewing |
+| Heading IDs injected via mdast post-processing, GitHub-compatible slugs | Reachable without a parser swap; fixes cross-page fragments and Pagefind anchors | Client-side only (today) -- invisible to crawlers, static consumers and deep links |
+| Second parser as an additive feature (`parser-cmark`), `markdown` stays default | Retains MDX and today's behaviour; group C becomes reachable for those who opt in | Swap wholesale (loses MDX); do nothing (group C unreachable) |
+| Unsupported config keys warn once at load | Silent acceptance is the current user-hostile failure shape (`book.toml` carries `# not implemented` comments) | Hard error (breaks existing `book.toml` files); stay silent (status quo) |
+
+### Eliminated options (essentialism)
+
+| Option rejected | Why rejected | Risk of including |
+|-----------------|--------------|-------------------|
+| Renderer trait with a single HTML impl | Speculative abstraction; no second renderer is planned | Indirection with no payoff; harder to follow |
+| Preprocessor plugin protocol (`mdbook-*` over stdio) | Premature before an internal preprocessing pipeline exists | Process spawning, JSON schema and version negotiation for zero current users |
+| Porting mdBook's CSS/themes verbatim | Contradicts the Terraphim design decision | Two design systems in one repo |
+| Emulating elasticlunr scoring on Pagefind | Pagefind has no equivalent knobs | Config that appears to work and does not |
+| Incremental/cached rebuilds | Not a stated problem; builds are fast on the corpus | Cache-invalidation bugs, non-deterministic output |
+
+### Simplicity check
+
+**What if this could be easy?** The whole of increment B is one parser plus one flatten
+function. `SUMMARY.md` is a markdown list; parse it into `Vec<BookItem>`; number it by walking
+the tree; flatten it once for the sidebar and once for prev/next. Everything else in this plan
+is either deleting a hard-coded value (syntect theme, `"Guide"` section title, absolute asset
+paths) or wiring an existing file into a template (`code-copy.js`).
+
+Complexity is admitted in exactly two places, both justified:
+
+1. The dual-parser feature flag (increment F) -- a directly approved decision, and additive.
+2. Keeping `sections` and `chapters` in the template context simultaneously -- a one-release
+   deprecation window, removed in the following release.
+
+**Senior engineer test**: the design adds ~4 focused modules and deletes structure-inference
+logic from `core.rs`. Net conceptual weight goes down, not up.
+
+**Nothing speculative checklist**:
+- [x] No features the user did not request (P2 explicitly deferred, not smuggled in)
+- [x] No abstractions "in case we need them later" (no renderer trait, no plugin protocol)
+- [x] No flexibility "just in case" (the preprocess seam is an identity function, not a registry)
+- [x] No error handling for impossible scenarios
+- [x] No premature optimization (benchmark first, per increment A gate)
+
+## File changes
+
+### New files
+
+| File | Purpose | Increment |
+|------|---------|-----------|
+| `src/book/mod.rs` | `Book`, `BookItem`, `Chapter`, `SectionNumber`; tree walk, flatten, numbering | B |
+| `src/book/summary.rs` | `SUMMARY.md` parser and its errors | B |
+| `src/book/directory.rs` | Today's directory-walk fallback, moved out of `core.rs` | B |
+| `src/pipeline/mod.rs` | Stage sequencing: `collect` → `preprocess` → `render` → `index` | A |
+| `src/pipeline/preprocess.rs` | Identity pass today; the designated seam for P2 | A |
+| `src/render/html.rs` | Tera context assembly, `path_to_root`, page/index/print/404/redirect writers | A, D, E |
+| `src/render/markdown.rs` | mdast splice + syntect + heading-ID injection; parser-backend switch | A, D, F |
+| `src/render/slug.rs` | GitHub-compatible heading slugs with per-page collision counters | D |
+| `src/paths.rs` | Book-directory / `src` / `build-dir` resolution and precedence | C |
+| `src/templates/css/themes.css` | CSS custom properties per theme | E |
+| `src/templates/js/theme-switch.js` | Theme toggle + `localStorage` persistence | E |
+| `src/templates/js/keyboard.js` | `←`/`→`/`s`/`/`/`?` shortcuts | E |
+| `src/templates/print.html.tera` | Single-document print page | E |
+| `src/templates/404.html.tera` | 404 page | D |
+| `src/templates/vendor/shoelace/*` | Vendored Shoelace 2.12.0 (CSS + autoloader) | D |
+| `tests/integration/summary_test.rs` | Summary parser unit/integration coverage | B |
+| `tests/integration/structure_test.rs` | Structural conformance over `test_book_mdbook/` | B |
+| `tests/fixtures/test_book_mdbook.structure.json` | Expected chapter tree, numbers, prev/next chain | B |
+
+### Modified files
+
+| File | Changes | Increment |
+|------|---------|-----------|
+| `src/core.rs` | Shrinks to `Args`, `build()` orchestration; collection/render/nav logic moves out; `"Guide"` section and path-order prev/next deleted | A, B |
+| `src/lib.rs` | `pub mod book; pub mod pipeline; pub mod render; pub mod paths;` + re-exports | A, B, C |
+| `src/main.rs` | `clap` subcommand dispatch; watch list from `build.extra-watch-dirs` | C |
+| `src/config.rs` | `book.src`, `build.*`, `output.html` additions (`default-theme`, `preferred-dark-theme`, `additional-css/js`, `input-404`, `site-url`, `no-section-label`, `[fold]`, `[print]`, `[redirect]`, `syntax-theme`); `book.toml` resolved from the book root; `warn_unsupported_keys()` | C, D, E |
+| `src/templates/page.html.tera` | `path_to_root` on every URL; vendored Shoelace; theme + keyboard + copy scripts; `additional-*` injection | D, E |
+| `src/templates/index.html.tera` | Same treatment | D, E |
+| `src/templates/sidebar.html.tera` | Renders the depth-tagged chapter list: part titles, separators, section numbers, draft chapters, fold | B, E |
+| `src/templates/header.html.tera` | Theme toggle control; print link | E |
+| `src/templates/js/code-copy.js` | Referenced from templates (currently dead code) | D |
+| `src/server.rs` | `-n/--hostname` bind address | C |
+| `tests/integration/mdbook_compatibility.rs` | Substring assertions replaced by structural ones | B |
+| `book.toml` | `# not implemented` comments removed as each key becomes real | B-E |
+| `README.md`, `CHANGELOG.md`, `.claude/skills/md-book` | Document subcommands, `SUMMARY.md`, themes; state P2 limits | all |
+
+### Deleted files
+
+| File | Reason |
+|------|--------|
+| none | Logic moves rather than disappears; `core.rs` shrinks in place |
+
+## API design
+
+### Public types (increment B)
+
+```rust
+// src/book/mod.rs
+
+/// A book: an ordered tree of items, as declared by SUMMARY.md
+/// (or inferred from the directory tree when no summary exists).
+#[derive(Debug, Clone, Serialize)]
+pub struct Book {
+    /// Top-level items in authored order.
+    pub items: Vec<BookItem>,
+    /// True when the structure came from SUMMARY.md rather than a directory walk.
+    pub from_summary: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum BookItem {
+    Chapter(Chapter),
+    /// `# Part Name` -- an unclickable heading in the sidebar.
+    PartTitle(String),
+    /// `---` -- a horizontal rule in the sidebar.
+    Separator,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Chapter {
+    /// Link text from SUMMARY.md, or the first H1, or the file stem.
+    pub name: String,
+    /// Source path relative to the book's `src` dir. `None` for draft chapters.
+    pub source_path: Option<PathBuf>,
+    /// Output path relative to the build dir, e.g. `individual/heading.html`.
+    /// `None` for draft chapters (rendered as a disabled sidebar entry).
+    pub output_path: Option<PathBuf>,
+    /// `1.2.3`; `None` for prefix, suffix and draft chapters.
+    pub number: Option<SectionNumber>,
+    /// Nested sub-chapters, in authored order.
+    pub sub_items: Vec<BookItem>,
+}
+
+/// Dotted section number, e.g. `SectionNumber(vec![1, 2, 3])` -> "1.2.3".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SectionNumber(pub Vec<u32>);
+
+/// One entry of the pre-flattened sidebar list handed to Tera
+/// (Tera has no template recursion, so nesting is expressed as `depth`).
+#[derive(Debug, Clone, Serialize)]
+pub struct NavEntry {
+    pub kind: NavKind,          // Chapter | PartTitle | Separator
+    pub title: String,
+    /// Root-relative href; `None` for drafts, part titles and separators.
+    pub href: Option<String>,
+    /// Rendered section number, e.g. "1.2."; empty when `no-section-label` is set.
+    pub number: String,
+    pub depth: usize,
+    pub is_draft: bool,
+    pub is_active: bool,
+}
+```
+
+### Public functions
+
+```rust
+// src/book/summary.rs
+
+/// Parse the contents of a `SUMMARY.md`.
+///
+/// # Errors
+/// - `SummaryError::MixedDelimiters` -- `-` and `*` both used for list items.
+/// - `SummaryError::PrefixAfterNumbered` -- a prefix chapter follows numbered chapters.
+/// - `SummaryError::Malformed` -- a list item that is not a link.
+pub fn parse_summary(content: &str) -> Result<Summary, SummaryError>;
+
+/// Build a `Book` from a summary, resolving paths against `src_dir` and
+/// assigning section numbers.
+///
+/// # Errors
+/// Returns `SummaryError::MissingFile` when a referenced file is absent and
+/// `build.create-missing` is false.
+pub fn book_from_summary(
+    summary: &Summary,
+    src_dir: &Path,
+    create_missing: bool,
+) -> Result<Book, SummaryError>;
+
+// src/book/directory.rs
+
+/// Today's behaviour: walk `src_dir`, sort by path, group by parent directory.
+/// Used when no `SUMMARY.md` exists.
+pub fn book_from_directory(src_dir: &Path) -> Result<Book>;
+
+// src/book/mod.rs
+
+impl Book {
+    /// Depth-first iteration over chapters in authored order -- the basis of
+    /// previous/next and of the Pagefind ordering.
+    pub fn iter_chapters(&self) -> impl Iterator<Item = &Chapter>;
+
+    /// Flatten to a sidebar list for Tera, marking `active_path` as active.
+    pub fn to_nav(&self, active_path: &Path, no_section_label: bool) -> Vec<NavEntry>;
+}
+
+// src/paths.rs (increment C)
+
+/// Resolved book locations. Precedence: CLI flag > book.toml > default.
+#[derive(Debug, Clone)]
+pub struct BookPaths { pub root: PathBuf, pub src: PathBuf, pub build: PathBuf }
+
+pub fn resolve(
+    book_dir: Option<&Path>,
+    input_override: Option<&str>,
+    output_override: Option<&str>,
+    config: &BookConfig,
+) -> Result<BookPaths>;
+
+// src/render/slug.rs (increment D)
+
+/// GitHub-compatible slug: lowercase, non-alphanumerics to `-`, collisions
+/// suffixed `-1`, `-2`, … via the caller-held counter.
+pub fn slugify(text: &str, seen: &mut HashMap<String, usize>) -> String;
+
+// src/render/html.rs (increment D)
+
+/// `../`-style prefix from a page to the build-dir root; `""` at the root.
+pub fn path_to_root(page: &Path) -> String;
+```
+
+### Error types
+
+```rust
+// src/book/summary.rs
+#[derive(Debug, thiserror::Error)]
+pub enum SummaryError {
+    #[error("SUMMARY.md line {line}: cannot mix '-' and '*' list delimiters")]
+    MixedDelimiters { line: usize },
+
+    #[error("SUMMARY.md line {line}: prefix chapter '{title}' appears after numbered chapters")]
+    PrefixAfterNumbered { line: usize, title: String },
+
+    #[error("SUMMARY.md line {line}: expected a markdown link, found: {text}")]
+    Malformed { line: usize, text: String },
+
+    #[error("SUMMARY.md references missing file: {path}")]
+    MissingFile { path: PathBuf },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+```
+
+## Test strategy
+
+No mocks (project rule). Every test builds real books from real fixtures.
+
+### Unit tests
+
+| Test | Location | Purpose |
+|------|----------|---------|
+| `test_parse_prefix_suffix_chapters` | `book/summary.rs` | Prefix before, suffix after numbered |
+| `test_parse_nested_chapters_three_deep` | `book/summary.rs` | Arbitrary nesting |
+| `test_parse_part_titles_and_separators` | `book/summary.rs` | `# Part` and `---` become items |
+| `test_parse_draft_chapter` | `book/summary.rs` | `- [Title]()` → `source_path: None` |
+| `test_parse_rejects_mixed_delimiters` | `book/summary.rs` | `MixedDelimiters` |
+| `test_parse_rejects_prefix_after_numbered` | `book/summary.rs` | `PrefixAfterNumbered` |
+| `test_section_numbering_matches_nesting` | `book/mod.rs` | `1`, `1.1`, `1.1.1`, `2` |
+| `test_prefix_suffix_draft_are_unnumbered` | `book/mod.rs` | `number: None` |
+| `test_readme_maps_to_index_html` | `book/mod.rs` | `README.md` → `index.html` |
+| `test_iter_chapters_authored_order` | `book/mod.rs` | Order ≠ path sort |
+| `test_to_nav_depth_and_active` | `book/mod.rs` | Depth tags, single active entry |
+| `test_path_to_root_depths` | `render/html.rs` | `""`, `"../"`, `"../../"` |
+| `test_slugify_matches_github` | `render/slug.rs` | Punctuation, case, unicode |
+| `test_slugify_collisions_suffixed` | `render/slug.rs` | `-1`, `-2` |
+| `test_resolve_precedence_cli_over_toml` | `paths.rs` | `-i` beats `book.src` |
+| `test_warn_unsupported_keys` | `config.rs` | Every rejected key warns once |
+
+### Integration tests
+
+| Test | Location | Purpose |
+|------|----------|---------|
+| `test_structure_matches_fixture` | `tests/integration/structure_test.rs` | Built tree vs `test_book_mdbook.structure.json` |
+| `test_files_absent_from_summary_not_published` | same | Summary-driven exclusion |
+| `test_prev_next_chain_follows_summary` | same | Walk the whole chain |
+| `test_no_summary_falls_back_to_directory` | same | `tests/assets/test_book_1` unchanged |
+| `test_existing_templates_still_render` | same | Flat `sections` still populated |
+| `test_output_has_no_absolute_asset_paths` | `tests/integration/build_test.rs` | No `href="/…"`/`src="/…"` |
+| `test_output_has_no_external_urls` | same | Offline output (Shoelace vendored) |
+| `test_headings_have_stable_ids` | same | Server-side `id` on every `<h1-6>` |
+| `test_404_and_redirects_written` | same | `404.html`, redirect stubs |
+| `test_print_page_contains_all_chapters` | same | `print.html` completeness |
+| `test_theme_toggle_present_and_persists` | `tests/frontend.test.js` | Browser-level theme check |
+| `test_build_subcommand_uses_book_toml_paths` | `tests/e2e/cli_test.rs` | `md-book build ./dir` |
+| `test_legacy_io_flags_still_work` | same | `-i/-o` regression |
+
+### Fixture strategy
+
+`tests/fixtures/test_book_mdbook.structure.json` is generated once from
+`test_book_mdbook/src/SUMMARY.md`, reviewed by hand against mdBook's own rendering, then
+committed. Structural assertions compare parsed trees, never HTML substrings -- replacing the
+false confidence in `tests/integration/mdbook_compatibility.rs:38-47`.
+
+## Implementation steps
+
+### Increment A -- pipeline decomposition (1-1.5 d)
+
+**A1. Extract stages** — `src/pipeline/mod.rs`, `src/render/html.rs`, `src/render/markdown.rs`,
+`src/core.rs`. Move code with zero behaviour change; `core::build` becomes orchestration.
+*Tests:* the existing suite must pass untouched. *Est:* 6 h.
+
+**A2. Add the preprocess seam** — `src/pipeline/preprocess.rs`: `fn preprocess(md: &str, ctx:
+&PreprocessCtx) -> Result<String>`, identity today, called before mdast parsing.
+*Tests:* `test_preprocess_identity_preserves_input`. *Est:* 1 h.
+
+**A3. Baseline benchmark** — record `benches/pagefind_bench.rs` numbers on `test_book_mdbook`
+before any later increment. *Est:* 1 h.
+
+**Gate:** `make ci-local` green, output byte-identical to pre-A build.
+
+### Increment B -- `SUMMARY.md` book model (4-5 d) [P0]
+
+**B1. Structure fixture first** — build `tests/fixtures/test_book_mdbook.structure.json` and the
+failing `structure_test.rs`. *Est:* 3 h.
+
+**B2. Summary parser** — `src/book/summary.rs` with the full unit table above. *Deps:* B1.
+*Est:* 8 h.
+
+**B3. Book model + numbering + flatten** — `src/book/mod.rs`: `Book`, `BookItem`, `Chapter`,
+`SectionNumber`, `iter_chapters`, `to_nav`; `README.md` → `index.html`. *Deps:* B2. *Est:* 8 h.
+
+**B4. Directory fallback** — move today's walk to `src/book/directory.rs`; select on
+`SUMMARY.md` presence; delete the `"Guide"` literal and the path-order prev/next
+(`core.rs:216-219`, `core.rs:274-284`). *Deps:* B3. *Est:* 4 h.
+
+**B5. Sidebar template** — nested rendering from `NavEntry`: part titles, separators, section
+numbers, disabled draft entries. Keep `sections` populated for one release. *Deps:* B4.
+*Est:* 5 h.
+
+**B6. Conformance** — rewrite `mdbook_compatibility.rs` onto structural assertions; make B1 pass.
+*Deps:* B5. *Est:* 4 h.
+
+**Gate:** `test_book_mdbook` structure matches the fixture exactly; `tests/assets/test_book_1`
+(no summary) renders as before.
+
+### Increment C -- CLI and path resolution (1.5-2 d)
+
+**C1. `src/paths.rs`** — precedence CLI > `book.toml` > default. *Est:* 3 h.
+**C2. Subcommands** — `build|serve|watch|init|clean [dir]`, `-d/--dest-dir`, `-n/--hostname`,
+`--open`; no-subcommand invocation keeps today's `-i/-o` behaviour. *Deps:* C1. *Est:* 6 h.
+**C3. Config from book root** — fix `config.rs:157-190` (currently CWD-only); add `book.src`,
+`build.*`; `extra-watch-dirs` into the watch list. *Deps:* C1. *Est:* 3 h.
+**C4. `init` scaffolding** — `book.toml`, `src/SUMMARY.md`, `src/chapter_1.md`, `.gitignore`.
+*Deps:* C2. *Est:* 2 h.
+
+**Gate:** `md-book build ./test_book_mdbook` works with no flags; every existing `-i/-o`
+invocation in CI, `Dockerfile` and `scripts/deploy.sh` still passes.
+
+### Increment D -- output-correctness defects (2-2.5 d) [P1]
+
+**D1. `path_to_root`** — compute per page; convert every template URL and `NavEntry.href`.
+*Est:* 5 h.
+**D2. Vendor Shoelace** — copy 2.12.0 CSS + autoloader into `src/templates/vendor/`; drop the
+jsDelivr tags; assert no external URLs in output. *Est:* 3 h.
+**D3. Server-side heading IDs** — `render/slug.rs` + mdast injection; `doc-toc.js` reuses
+existing IDs instead of minting them. *Est:* 5 h.
+**D4. 404 page** — `input-404`, `site-url`; render `404.html`. *Est:* 2 h.
+**D5. Copy button** — reference `js/code-copy.js` from templates (dead since it was added).
+*Est:* 1 h.
+
+**Gate:** built output loads from `file://` and from a sub-path with no network.
+
+### Increment E -- renderer polish (2-3 d) [P3]
+
+**E1. Themes** — `themes.css` custom properties for light/rust/coal/navy/ayu; toggle with
+`localStorage`; `default-theme` / `preferred-dark-theme`. *Est:* 8 h.
+**E2. Configurable syntax theme** — `output.html.syntax-theme`, replacing the hard-coded
+`"Solarized (light)"` (`core.rs:242`); a light and a dark stylesheet emitted. *Deps:* E1.
+*Est:* 3 h.
+**E3. Print page** — `print.html.tera`, `print.css`, `[output.html.print]` enable/page-break.
+*Est:* 4 h.
+**E4. `additional-css` / `additional-js`** — copy and inject. *Est:* 2 h.
+**E5. Redirects + fold** — `[output.html.redirect]` stub pages; `[output.html.fold]` collapse
+depth. *Est:* 4 h.
+**E6. Keyboard shortcuts** — `←`/`→`/`s`/`/`/`?`. *Est:* 2 h.
+
+**Gate:** theme choice persists across pages; `print.html` contains every chapter in book order.
+
+### Increment F -- `pulldown-cmark` backend (designed only; separate cycle)
+
+Interface fixed now so increment A's `render/markdown.rs` split is right:
+
+```rust
+// src/render/markdown.rs
+pub trait MarkdownBackend {
+    /// Render markdown to an HTML fragment, highlighting code blocks.
+    fn render(&self, content: &str, config: &BookConfig) -> Result<String>;
+}
+
+#[cfg(feature = "parser-markdown")] pub struct MarkdownCrateBackend;  // default; MDX
+#[cfg(feature = "parser-cmark")]    pub struct CmarkBackend;          // footnotes, deflists,
+                                                                       // admonitions, smart punct
+```
+
+```toml
+# Cargo.toml
+[features]
+default = ["server", "watcher", "search", "syntax-highlighting", "parser-markdown"]
+parser-markdown = []                          # markdown 1.0.0-alpha.21, MDX
+parser-cmark    = ["pulldown-cmark"]          # 0.13.4, mdBook-compatible extensions
+```
+
+Constraint: the two features are additive but the *active* backend is one, selected by
+`markdown.parser` in `book.toml` and defaulting to whichever is compiled in. Both backends must
+satisfy the same conformance fixtures for content the `markdown` crate can already express;
+group C features are asserted only under `parser-cmark`.
+
+## Rollback plan
+
+Each increment is a separate PR against `main` and is revertable on its own.
+
+1. **B** is the only behaviour-breaking increment. If summary mode misbehaves in the field,
+   revert the mode selector in `src/core.rs` (one call site) to force
+   `book_from_directory` -- the parser stays in the tree, dormant.
+2. **D1** (`path_to_root`) is the riskiest cosmetic change: revert the template commit; the Rust
+   side is additive (the variable becomes unused).
+3. **C** is additive; reverting restores flag-only invocation.
+4. No data migration, no persistent state, no feature-flag runtime needed beyond the above.
+
+## Dependencies
+
+### New dependencies
+
+| Crate | Version | Justification | Increment |
+|-------|---------|---------------|-----------|
+| `pulldown-cmark` | 0.13.4 | Optional second parser backend; behind `parser-cmark` | F (not now) |
+
+No new dependency is required for A-E. Summary parsing uses the existing `markdown` crate's
+mdast (a `SUMMARY.md` is a markdown document); slugging and `path_to_root` are `std`. Shoelace is
+vendored as static assets, not as a dependency. WASM builds keep compiling because everything
+added is `std`-only or behind existing feature gates.
+
+## Performance considerations
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Full build, `test_book_mdbook` | Within 10% of the A3 baseline | `benches/pagefind_bench.rs` |
+| Summary parse | < 5 ms for 500 entries | New criterion bench |
+| Watch rebuild | No regression vs today | Manual, `--watch` |
+
+Benchmarks to add:
+
+```rust
+// benches/summary_bench.rs
+fn bench_parse_summary_500_entries(c: &mut Criterion) { /* generated fixture */ }
+fn bench_book_to_nav_500_chapters(c: &mut Criterion) { /* to_nav on every page */ }
+```
+
+`to_nav` runs once per page, so it is O(pages × chapters). At the corpus size (30 pages) this is
+irrelevant; if a book exceeds ~1,000 chapters, hoist the flatten out of the page loop and mutate
+only `is_active`. **Do not do this pre-emptively** -- measure first.
+
+## Open items
+
+| Item | Status | Owner |
+|------|--------|-------|
+| Sign-off on the research doc's Interpretation B (contract parity) | **Resolved** -- approved 2026-08-08 | Alex |
+| Directory-derived section titles (the literal `"Guide"`) | **Resolved** -- nothing depends on them; `dist/` is a demo build of the defective output | Claude |
+| Sub-path deployment priority | **Resolved** -- not needed by this repo (root-published `dist`), needed by md-book's GitHub Pages users; `path_to_root` stays in D | Alex |
+| Warn vs. silent for unsupported config keys | **Resolved** -- warn once on stderr at config load | Alex |
+| Gitea issues per increment, with `Refs #IDX` on every commit | Created -- `terraphim/md-book` #1-#5, dependency-ordered | Claude |
+| P2 preprocessing research cycle (`{{#include}}`, anchors, hidden lines, Rust attributes) | Deferred | -- |
+| Increment F implementation cycle | Deferred | -- |
+
+## Approval
+
+- [x] Technical review complete
+- [x] Test strategy approved
+- [x] Performance targets agreed
+- [x] Increment sequencing agreed (A → B → C → D → E, F later)
+- [x] Human approval received -- Alex Mikhalev, 2026-08-08
+
+**Next phase:** `disciplined-specification` (Phase 2.5) on increment B before any code is
+written -- the summary parser has the most edge cases (mixed delimiters, missing files,
+`create-missing`, non-UTF-8 paths, duplicate entries, links with anchors or query strings).
+Findings are appended to this document.

--- a/docs/plans/mdbook-parity-research.md
+++ b/docs/plans/mdbook-parity-research.md
@@ -1,0 +1,422 @@
+# Research Document: mdBook Feature Parity
+
+**Status**: Approved (2026-08-08)
+**Author**: Claude (Opus 5), with Alex Mikhalev
+**Date**: 2026-08-08
+**Reviewers**: Alex Mikhalev
+**Phase**: 1 (disciplined-research)
+
+## Executive Summary
+
+md-book is not a git fork of mdBook -- it is an independent Rust reimplementation that reuses
+mdBook's `book.toml` shape and the `MDBOOK_` environment prefix. It currently implements roughly
+a third of mdBook's documented surface. The single largest divergence is that **md-book has no
+`SUMMARY.md` parser at all**: book structure is inferred from a `walkdir` traversal sorted by
+path, with sections derived from parent directory names. Everything mdBook builds on top of the
+summary (ordering, nesting, numbering, prefix/suffix chapters, draft chapters, part titles,
+file exclusion, correct previous/next) is therefore absent or wrong.
+
+Three other structural gaps compound this: no preprocessor/link-expansion layer
+(`{{#include}}`, anchors, `{{#playground}}`), no theme/print/404/redirect renderer features,
+and no server-side heading IDs (added client-side only by `doc-toc.js`).
+
+Several md-book decisions are deliberate improvements and must be retained: Pagefind instead
+of elasticlunr, Tera instead of Handlebars, Web Components, the `markdown` crate (CommonMark /
+GFM / MDX), `twelf` layered configuration, `jiff`, and the WASM build target. Parity should be
+read as **behavioural parity of the authored book contract**, not as reimplementing mdBook's
+internals.
+
+## Essential Questions Check
+
+| Question | Answer | Evidence |
+|----------|--------|----------|
+| Energizing? | Yes | md-book is positioned in `Cargo.toml` and `README.md` as "a modern mdbook replacement"; a replacement that cannot build an existing mdBook book does not meet its own claim. |
+| Leverages strengths? | Yes | Rust performance work, Pagefind, Web Components and Terraphim's docs pipeline are existing in-house capability; `test_book_mdbook/` (mdBook's own test book) is already vendored as a conformance corpus. |
+| Meets real need? | Yes | `test_book_mdbook/src/SUMMARY.md` uses prefix chapters, draft chapters, part titles and separators -- none of which md-book honours today, so the vendored corpus renders incorrectly. Terraphim docs are the immediate consumer. |
+
+**Proceed**: Yes (3/3).
+
+## Problem Statement
+
+### Description
+
+md-book claims to replace mdBook but cannot faithfully render an mdBook book. Given an existing
+`src/` + `SUMMARY.md`, md-book will emit pages in path-sorted order, invent sections from
+directory names, ignore the author's declared structure, silently publish files the author
+excluded from the summary, and drop every `{{#include}}` directive as literal text.
+
+### Impact
+
+- **Migrating users** (the stated target): output is structurally wrong on the first build; the
+  failure is silent, not an error.
+- **Terraphim docs**: cannot move off mdBook without hand-restructuring content into
+  directory-per-section shape.
+- **The vendored conformance corpus** (`test_book_mdbook/`) passes today's tests only because
+  those tests assert file existence and substring presence, not structure
+  (`tests/integration/mdbook_compatibility.rs:38-47`).
+
+### Success Criteria
+
+1. `md-book -i test_book_mdbook/src -o out` produces a sidebar, ordering, and previous/next
+   chain that matches `test_book_mdbook/src/SUMMARY.md` exactly, including prefix chapters,
+   part titles, draft chapters and separators.
+2. Files present in `src/` but absent from `SUMMARY.md` are not published.
+3. A book with `{{#include}}` / anchors renders the included content.
+4. Generated pages carry stable server-side heading IDs.
+5. Output is deployable under a sub-path and offline (no CDN requirement).
+6. No regression in the retained local decisions (Pagefind, Tera, Web Components, WASM).
+
+## Current State Analysis
+
+### Existing Implementation
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| CLI args | `src/core.rs:27-56` | Single command: `-i`, `-o`, `-c`, `--watch`, `--serve`, `--port`. No subcommands. |
+| Build pipeline | `src/core.rs:129-386` | Template load, asset copy, walkdir collect, per-file render, index render. |
+| Navigation model | `src/core.rs:170-225` | `BTreeMap<parent_dir, Vec<PageInfo>>`; root pages forced into a section literally titled `"Guide"`. |
+| Previous/next | `src/core.rs:274-284` | Index into path-sorted `all_pages` -- not authored order. |
+| Title extraction | `src/core.rs:388-393` | First line starting `"# "`; raw markdown is kept verbatim (`**bold**` leaks into `<title>`). |
+| Markdown → HTML | `src/core.rs:714-879` | `markdown` crate; code blocks spliced out by mdast offset and re-highlighted with syntect. |
+| Link rewriting | `src/core.rs:640-712` | Manual `href="…md"` → `.html` scan over rendered HTML. |
+| Config | `src/config.rs:1-190` | `twelf` layers: `MDBOOK_` env → `book.toml` → custom `.toml`/`.json`. |
+| Config load | `src/config.rs:157-190` | `book.toml` only read from the **current working directory**, not the book directory. |
+| Search | `src/pagefind_service.rs` | Pagefind CLI subprocess after HTML generation. |
+| Server | `src/server.rs`, `src/main.rs:183-240` | warp static + WebSocket reload; `notify` watcher with 500 ms debounce. |
+| Templates | `src/templates/*.tera` | `page`, `index`, `sidebar`, `header`, `footer`; overridable via `paths.templates`. |
+| Components | `src/templates/components/*.js` | `doc-toc`, `doc-sidebar`, `search-modal`, `simple-block`. |
+
+### Data Flow
+
+`walkdir(input)` → filter `*.md` → sort by path → `PageInfo{title, path}` → group by parent dir
+→ per-file: read → mdast → splice code blocks → highlight → HTML → `.md`→`.html` rewrite →
+Tera `page` → write → (async) Pagefind index over the output directory.
+
+There is no intermediate book model, no preprocessing stage, and no renderer abstraction.
+
+### Integration Points
+
+`pagefind` CLI (must be on `PATH`); Shoelace 2.12.0 via jsDelivr CDN (`page.html.tera:12-13`);
+`mermaid.min.js` (vendored); `syntect` default theme set.
+
+## Parity Matrix
+
+Legend: **Have** = implemented; **Partial** = present but divergent/incomplete; **Missing**;
+**N/A (local decision)** = deliberately not matching mdBook.
+
+### A. Book structure and navigation
+
+| mdBook feature | md-book | Evidence / note |
+|---|---|---|
+| `SUMMARY.md` as source of truth | **Missing** | `src/core.rs:175-225` walks the directory instead. |
+| Chapter ordering from summary | **Missing** | Path-sorted (`core.rs:182`). |
+| Nested sub-chapters (arbitrary depth) | **Missing** | Flat one-level `section → pages`. |
+| Part titles (`# Part Name`) | **Missing** | -- |
+| Prefix / suffix chapters | **Missing** | -- |
+| Draft chapters (`- [Title]()`) | **Missing** | -- |
+| Separators (`---`) | **Missing** | -- |
+| Section numbering (`1.1`), `no-section-label` | **Missing** | -- |
+| Exclude files not in summary | **Missing** | Every `*.md` under input is published. |
+| `README.md` → `index.html` (index preprocessor) | **Missing** | Requires `index.md`; `core.rs:347-371`. |
+| Correct previous/next | **Partial** | Exists, but ordered by path (`core.rs:274-284`). |
+| `book.src` config key | **Missing** | Source dir comes from `-i` only. |
+| `build.build-dir`, `create-missing`, `extra-watch-dirs` | **Missing** | `-o` only; templates dir is watched (`main.rs:150`). |
+
+### B. CLI surface
+
+| mdBook | md-book | Note |
+|---|---|---|
+| `init` (+`--theme`, `--title`, `--ignore`, `--force`) | **Missing** | No scaffolding path. |
+| `build` / `watch` / `serve` / `clean` / `completions` subcommands | **Partial** | Single command with `--watch` / `--serve` flags. |
+| `serve -n <hostname>`, `--open`, `-d/--dest-dir`, `--watcher poll\|native` | **Missing** | Only `--port`. |
+| `test` (rustdoc doctests) | **Missing** | Requires a Rust toolchain integration. |
+
+### C. Markdown, preprocessing, code
+
+| mdBook | md-book | Note |
+|---|---|---|
+| `{{#include file}}` + `:line` ranges | **Missing** | Emitted literally. |
+| `ANCHOR:` / `ANCHOR_END:` anchors | **Missing** | -- |
+| `{{#rustdoc_include}}`, `{{#playground}}` | **Missing** | -- |
+| `{{#title …}}` | **Missing** | -- |
+| Hidden lines (`# ` prefix, `hidelines=`) | **Missing** | Rust `#` lines render verbatim. |
+| Rust attributes: `ignore`, `no_run`, `should_panic`, `compile_fail`, `editable`, `noplayground`, `editionYYYY` | **Missing** | `core.rs:560-596` only branches on `rust` / `mermaid` / other; an unknown token such as `rust,ignore` fails syntax lookup and falls back to plain text. |
+| MathJax `\\(…\\)` / `\\[…\\]` | **Missing** | `mathjax-support` parses but is unused; test ignored at `core.rs:1109`. |
+| Smart punctuation | **Missing** | -- |
+| Footnotes | **Missing** | Not in the `markdown` crate's GFM set. |
+| Definition lists, admonitions (`> [!NOTE]`) | **Missing** | -- |
+| Heading attributes `{ #id .class }` | **Missing** | -- |
+| Heading anchor IDs in HTML | **Missing** | No `id` on any `<h*>` in generated output (verified against `dist_test_2/*.html`); `doc-toc.js:28-39` injects them client-side only, so cross-page `#fragment` links and Pagefind anchors fail. |
+| Strikethrough / tables / task lists | **Have** | Via GFM mode. |
+| `.md` → `.html` link conversion | **Have** | `core.rs:640-712`. |
+| Preprocessor protocol (`mdbook-*`, JSON over stdio) | **Missing** | No plugin surface. |
+| Alternative backends (`[output.*]`), `markdown` renderer | **Missing** | HTML only. |
+| Mermaid diagrams | **Have (superset)** | mdBook needs a third-party preprocessor. |
+| MDX input | **Have (superset)** | -- |
+
+### D. HTML renderer
+
+| mdBook | md-book | Note |
+|---|---|---|
+| Themes: Light/Rust/Coal/Navy/Ayu + toggle, `default-theme`, `preferred-dark-theme` | **Missing** | Single stylesheet. |
+| Print page (`print.html`, `print.css`, `page-break`) | **Missing** | -- |
+| 404 page (`input-404`, `site-url`) | **Missing** | -- |
+| `[output.html.redirect]` map | **Missing** | -- |
+| `additional-css` / `additional-js` | **Missing** | -- |
+| Sidebar fold (`[output.html.fold]`) | **Missing** | -- |
+| Keyboard shortcuts (←/→, `s`, `/`, `?`) | **Missing** | -- |
+| Copy-to-clipboard button | **Partial** | `js/code-copy.js` exists but is referenced by no template -- dead code. |
+| Configurable syntax theme | **Missing** | `"Solarized (light)"` hard-coded, `core.rs:242` (marked TODO). |
+| `git-repository-url` / `-icon` | **Partial (renamed)** | Local `book.github_url`. |
+| `edit-url-template` with `{path}` | **Partial (renamed)** | Local `book.github_edit_url_base` + suffix. |
+| `cname`, `hash-files`, `text-direction` | **Missing** | -- |
+| Relative asset paths (`path_to_root`) | **Missing (defect)** | Templates hard-code absolute `/css/...`, `/js/...`, and `PageInfo.path` is `/`-prefixed (`core.rs:196`), so output only works at a domain root. |
+| Self-contained offline output | **Missing (defect)** | Shoelace loaded from jsDelivr (`page.html.tera:12-13`); mdBook output is fully offline. |
+| Search backend | **N/A (local decision)** | Pagefind replaces elasticlunr. Consequence: `use-boolean-and`, `boost-*`, `expand`, `teaser-word-count`, `copy-js` have no Pagefind equivalent; `limit-results` and `heading-split-level` do. These keys parse today and are silently ignored. |
+| Templating engine | **N/A (local decision)** | Tera, not Handlebars: `index.hbs`/`head.hbs`/`{{#toc}}`/`{{fa}}` will not be supported. |
+| SEO: canonical URL, meta description, skip link | **Have (superset)** | Added by the browser-validation work. |
+
+## Constraints
+
+### Technical Constraints
+
+- **`markdown` crate (1.0.0-alpha.21)** does not emit heading IDs, footnotes, definition lists,
+  admonitions, smart punctuation, or heading attributes. Several C-row gaps therefore require
+  either post-processing the HTML/mdast or changing parser. mdBook itself uses `pulldown-cmark`.
+- **Code-block splicing by byte offset** (`core.rs:747-813`) means any preprocessing that
+  rewrites markdown must run *before* this stage, on the markdown text, not on the HTML.
+- **WASM target** must keep building: any new dependency has to be optional or wasm-safe
+  (`features = ["wasm", "wasm-core"]`).
+- **Pagefind CLI** is an external process; search remains a post-build step.
+- Global project rules: no mocks in tests, `jiff` not `chrono`, British English, no emoji.
+
+### Business Constraints
+
+- md-book is not a Q3 priority in the current North Star; this work must be decomposable into
+  small, independently shippable increments rather than one long migration.
+- Existing published output (`dist/`, deploy workflows, Cloudflare Pages) must keep building.
+
+### Non-Functional Requirements
+
+| Requirement | Target | Current |
+|-------------|--------|---------|
+| Build determinism | Identical output for identical input | Met (path sort), but authored order not honoured |
+| Sub-path deployment | Works under `/docs/` | Fails (absolute asset paths) |
+| Offline output | No network at view time | Fails (Shoelace CDN) |
+| Build speed | No worse than today on the vendored corpus | Baseline: `benches/pagefind_bench.rs` |
+
+## Vital Few (Essentialism)
+
+### Essential Constraints (max 3)
+
+| Constraint | Why it's vital | Evidence |
+|------------|----------------|----------|
+| `SUMMARY.md` must become the book model | Every ordering, navigation, numbering and exclusion behaviour derives from it; without it no other parity item is observable to a migrating user. | `core.rs:170-225` vs `test_book_mdbook/src/SUMMARY.md` |
+| Preprocessing must run on markdown before code-block splicing | `{{#include}}` and hidden-line handling are textual; retro-fitting them after HTML generation would break syntax highlighting. | `core.rs:747-813` |
+| Local decisions are non-negotiable | Pagefind, Tera, Web Components, `markdown` crate, WASM. Parity means the *authored book contract*, not mdBook internals. | User instruction; `Cargo.toml` features |
+
+### Eliminated from Scope (5/25 rule)
+
+| Eliminated item | Why eliminated |
+|-----------------|----------------|
+| Handlebars theme compatibility (`index.hbs`, `{{#toc}}`, `{{fa}}`) | Contradicts the Tera decision; would fork the template layer. |
+| elasticlunr search + its config semantics (`boost-*`, `expand`, `use-boolean-and`, `teaser-word-count`) | Contradicts the Pagefind decision. Resolve by documenting these keys as unsupported rather than accepting them silently. |
+| `mdbook test` (rustdoc doctests) | Requires toolchain orchestration; large, isolated, and unused by Terraphim docs. |
+| Rust Playground integration (run button, editable editor, `[output.html.playground]` runtime) | Rust-book-specific; only the *rendering* attributes matter for correctness. |
+| Preprocessor / alternative-backend plugin protocol (`mdbook-*` over stdio) | Only worth building once an internal preprocessing pipeline exists; premature now. |
+| `hash-files`, `cname`, `text-direction`, `completions` | Low value relative to the structural gaps. |
+
+## Dependencies
+
+### Internal
+
+| Dependency | Impact | Risk |
+|------------|--------|------|
+| `src/core.rs` `build_sync_impl_sync` | Single 250-line function owning collection, rendering and indexing; every structural change lands here. | High -- needs decomposition first |
+| `src/templates/sidebar.html.tera` | Assumes flat `sections[].pages[]`; nesting changes the contract. | Medium -- breaks user-overridden templates |
+| `tests/integration/mdbook_compatibility.rs` | Asserts substrings, not structure; gives false confidence. | Medium |
+| `src/config.rs` | `book.toml` resolved from CWD, not book dir; blocks `mdbook build <dir>` semantics. | Medium |
+
+### External
+
+| Dependency | Version | Risk | Alternative |
+|------------|---------|------|-------------|
+| `markdown` | 1.0.0-alpha.21 | Alpha; lacks heading IDs/footnotes/admonitions; pinning risk | `pulldown-cmark` (what mdBook uses) -- a large, separate decision |
+| `pagefind` | 1.3.0 | External CLI must be installed | Bundled crate API |
+| `syntect` | 5.0 | Theme set fixed at build | -- |
+| Shoelace | 2.12.0 CDN | Network dependency in output | Vendor locally |
+
+## Risks and Unknowns
+
+### Known Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Introducing `SUMMARY.md` breaks existing directory-driven books (including Terraphim's own docs and `dist/` deploys) | High | High | Fall back to today's directory walk when no `SUMMARY.md` is present; make summary mode opt-in-by-presence, never mandatory. |
+| Nested navigation breaks user-supplied Tera templates | Medium | Medium | Keep the flat `sections` variable populated alongside a new `chapters` tree for one release; document the deprecation. |
+| `markdown` crate cannot supply heading IDs / footnotes / admonitions | High | Medium | Post-process mdast (IDs, achievable) and defer footnotes/admonitions/definition lists to a separate parser decision. |
+| Parser swap to `pulldown-cmark` becomes the real blocker for group C | Medium | High | Treat it as its own research/design cycle; do not bundle it into this plan. |
+| Scope creep into full mdBook internals | High | Medium | The Eliminated table above is binding. |
+| Rebuild performance degrades with a preprocessing pass | Low | Low | Benchmark against `benches/pagefind_bench.rs` before/after. |
+
+### Open Questions -- all resolved 2026-08-08
+
+1. **CLI shape** -- *Resolved*: add `md-book build|serve|watch|init|clean [dir]` honouring
+   `book.src` / `build.build-dir`, and keep `-i/-o` as overrides so CI, `Dockerfile` and
+   `scripts/deploy.sh` stay green.
+2. **Parser stance** -- *Resolved*: `pulldown-cmark` becomes an additive, feature-flagged second
+   backend (`parser-cmark`); the `markdown` crate stays the default and MDX is retained. Group C
+   markdown features become reachable under the opt-in backend rather than being deferred
+   outright. Implementation is its own cycle (increment F).
+3. **Unsupported config keys** -- *Resolved*: warn once on stderr at config load. Silent
+   acceptance is the current failure shape; a hard error would break every existing `book.toml`,
+   including this repo's (three such keys today).
+4. **Sub-path deployment** -- *Resolved*: not required by this repo's own consumers (Cloudflare
+   Pages and Netlify both publish `dist` at domain root; the one gh-pages sub-path step
+   publishes rustdoc from `target/doc`, not md-book output). It **is** required by md-book's
+   users on GitHub Pages project sites, so `path_to_root` stays in increment D alongside the
+   other relocatability/offline defects, which touch the same template lines.
+
+Additionally verified during Phase 2, closing two assumptions from the table above:
+
+5. **Directory-derived section titles** -- nothing depends on them. The only artefact showing
+   them is `dist/`, a demo build of `test_book_mdbook` whose sidebar reads
+   `Guide / headings / individual / languages / rust` -- i.e. the defective output this work
+   replaces.
+6. **User-supplied templates** -- only this repo's `paths.templates = "src/templates"` was found;
+   the one-release `sections` deprecation window is sufficient.
+
+### Assumptions Explicitly Stated
+
+| Assumption | Basis | Risk if wrong | Verified? |
+|------------|-------|---------------|-----------|
+| "Fork" means "independent reimplementation", not a git fork | No mdBook history in `git log`; no `pulldown-cmark`/`handlebars` in `Cargo.toml` | Wording only | Yes |
+| Parity target is mdBook's *authored-book contract*, not its internals | User instruction to retain local decisions | Would mean reverting Pagefind/Tera | Stated, needs sign-off |
+| `test_book_mdbook/` is the intended conformance corpus | Vendored, plus three dedicated test targets in `Cargo.toml` | Would need a new corpus | Yes |
+| No consumer currently depends on directory-derived section titles (e.g. the literal `"Guide"` section) | `core.rs:216-219`; Terraphim docs use directories | Sidebar labels change for existing books | No -- check `dist/` |
+| Existing user templates are rare (only `paths.templates` in this repo's `book.toml`) | Repo inspection | Breaking template change affects users | No |
+
+### Multiple Interpretations Considered
+
+| Interpretation | Implications | Chosen / rejected |
+|----------------|--------------|-------------------|
+| **A. Byte-level parity** -- match mdBook's HTML, themes and Handlebars | Reverts Pagefind, Tera, Web Components | **Rejected** -- contradicts "retain local decisions" |
+| **B. Contract parity** -- any valid mdBook book builds correctly, with md-book's own presentation | Requires `SUMMARY.md`, preprocessing, renderer features; keeps local stack | **Chosen** |
+| **C. Config parity only** -- accept every `book.toml` key, implement what is cheap | Cheap, but silently wrong output; today's failure mode | **Rejected** |
+
+## Research Findings
+
+### Key Insights
+
+1. **The parity gap is structural, not cosmetic.** One missing artefact (`SUMMARY.md`) accounts
+   for eleven of the thirteen A-row gaps and makes previous/next incorrect.
+2. **Feature gaps are already encoded as configuration.** `book.toml` in this repo carries
+   `# not implemented` comments on `mathjax-support`, `playground` and `search` -- config
+   acceptance has outrun behaviour, which is the most user-hostile failure shape.
+3. **Two defects are worse than missing features**: absolute asset paths (breaks sub-path
+   deployment) and CDN-loaded Shoelace (breaks offline/air-gapped viewing). mdBook output is
+   relocatable and self-contained; md-book's is neither.
+4. **Group C is parser-bound.** Heading IDs are reachable via mdast post-processing, but
+   footnotes, definition lists, admonitions and smart punctuation are properties of the parser.
+   Recognising this prevents a doomed incremental effort.
+5. **`{{#include}}` must be a pre-parse text pass**, sequenced ahead of the existing offset-based
+   code-block splice.
+6. **Existing "compatibility" tests do not test compatibility.** They assert files exist and
+   contain substrings; a structural fixture comparison is needed for any of this to be provable.
+7. **`build_sync_impl_sync` must be decomposed first.** Collection, preprocessing, rendering and
+   indexing are one function; every parity item otherwise piles into it.
+
+### Relevant Prior Art
+
+- **mdBook** (`rust-lang/mdBook`) -- `SummaryParser`, `links` and `index` preprocessors, the
+  `Book`/`BookItem` model: the reference for the book model shape.
+- **mdBook's own test book** (`test_book_mdbook/`) -- already vendored; exercises prefix, draft,
+  part titles, separators and per-tag markdown cases.
+- **`docs/plans/browser-validation-research.md`** -- the in-repo precedent for this document
+  shape; its explicit "Out of scope: a full `SUMMARY.md` parser" is the deferral this document
+  now takes up.
+
+### Technical Spikes Needed
+
+| Spike | Purpose | Effort |
+|-------|---------|--------|
+| mdast heading-ID injection | Confirm stable GitHub-compatible slugs can be produced from `markdown` crate mdast without a parser swap | 2-4 h |
+| Nested sidebar in Tera | Confirm recursive rendering of a chapter tree in Tera (no native recursion; needs a macro or pre-flattened list) | 2 h |
+| `pulldown-cmark` evaluation | Cost of migration; whether MDX can be dropped | 1 day (separate cycle) |
+
+## Recommendations
+
+### Proceed / No-Proceed
+
+**Proceed**, with interpretation B (contract parity), scoped to four sequenced increments and
+explicitly excluding the Eliminated table. The prerequisite for all of them is decomposing
+`build_sync_impl_sync` into collect → preprocess → render → index stages.
+
+### Scope Recommendations
+
+Priority order, by user-visible correctness per unit of effort:
+
+1. **P0 -- Book model**: `SUMMARY.md` parser, chapter tree, correct ordering/previous/next,
+   `README.md`→`index.html`, summary-driven exclusion, part titles, prefix/suffix, draft
+   chapters, separators, section numbers. Directory-walk fallback preserved.
+2. **P1 -- Output correctness defects**: relative asset paths (`path_to_root`), vendored
+   Shoelace, server-side heading IDs, 404 page, wire up the dead copy button.
+3. **P2 -- Preprocessing**: `{{#include}}` with line ranges and anchors, `{{#title}}`, hidden
+   lines, Rust code-block attribute parsing (`rust,ignore` etc. must not degrade highlighting).
+4. **P3 -- Renderer polish**: theme switching (light/dark), configurable syntax theme, print
+   page, `additional-css`/`additional-js`, redirects, sidebar fold, keyboard shortcuts.
+
+Cross-cutting: replace substring assertions with structural fixtures over `test_book_mdbook/`,
+and make unsupported config keys warn rather than parse silently.
+
+### Risk Mitigation Recommendations
+
+- Gate the summary parser on the presence of `src/SUMMARY.md`; never break directory-mode books.
+- Ship the chapter tree *alongside* the existing flat `sections` template variable for one
+  release, with a documented deprecation.
+- Benchmark before and after the preprocessing pass.
+- Record the parser question (`pulldown-cmark`) as its own research cycle rather than absorbing
+  it here.
+
+## Next Steps
+
+If approved:
+
+1. Answer open questions 1-4 (CLI shape, parser stance, warning policy, sub-path requirement).
+2. Proceed to Phase 2 (`disciplined-design`) for the P0 increment:
+   `docs/plans/mdbook-parity-implementation-plan.md`.
+3. Build the structural conformance fixture over `test_book_mdbook/` before implementation.
+
+## Appendix
+
+### Reference Materials
+
+- mdBook documentation: <https://rust-lang.github.io/mdBook/>
+- In-repo corpus: `test_book_mdbook/src/SUMMARY.md`
+- Precedent: `docs/plans/browser-validation-research.md`
+
+### Code Snippets
+
+Current navigation derivation -- the crux of the A-row gaps (`src/core.rs:201-225`):
+
+```rust
+if parent_dir.is_empty() {
+    root_pages.push(page_info);
+} else {
+    section_map.entry(parent_dir.to_string()).or_default().push(page_info);
+}
+// ...
+if !root_pages.is_empty() {
+    sections.push(Section { title: "Guide".to_string(), pages: root_pages });
+}
+for (title, pages) in section_map {
+    sections.push(Section { title, pages });   // section title == directory name
+}
+```
+
+Previous/next by path order rather than authored order (`src/core.rs:274-284`):
+
+```rust
+let previous = if current_page > 0 { Some(all_pages[current_page - 1].clone()) } else { None };
+let next = if current_page + 1 < total_pages { Some(all_pages[current_page + 1].clone()) } else { None };
+```

--- a/docs/plans/review-mdbook-parity-a.md
+++ b/docs/plans/review-mdbook-parity-a.md
@@ -1,0 +1,28 @@
+# Structural review: mdBook parity Increment A
+
+**Date**: 2026-08-08  
+**Branch**: `task/1-pipeline-decomposition`  
+**Scope**: Pipeline decomposition only
+
+## Findings
+
+No P0/P1 issues found.
+
+### Notes (informational)
+
+1. **Module cycle is intentional and safe**: `pipeline` uses `core::{Args, PageInfo}`; `core` calls `pipeline::run_sync`. Same-crate cycle; no runtime risk.
+2. **`write_syntax_css` still hard-codes Solarized (light)** — deferred to Increment E by plan; left with TODO comment.
+3. **`"Guide"` section title** — deferred to B; intentionally preserved for byte-identical gate.
+4. **`render_markdown` takes `Option<&SyntaxSet>`** — feature-gated; clean call sites with `cfg`.
+
+## Security
+
+No new attack surface. No path handling changes beyond move of existing walkdir logic.
+
+## Performance
+
+No algorithmic change. Wall clock ~0.86 s for `test_book_mdbook` (debug).
+
+## Verdict
+
+Approve for merge after CI green on PR.

--- a/docs/validation/validation-report-mdbook-parity-a.md
+++ b/docs/validation/validation-report-mdbook-parity-a.md
@@ -1,0 +1,29 @@
+# Validation Report: mdBook parity Increment A
+
+**Date**: 2026-08-08  
+**Change slug**: mdbook-parity-a  
+**Issue**: terraphim/md-book#1
+
+## Acceptance criteria (from plan gate)
+
+| Criterion | Evidence | Status |
+|-----------|----------|--------|
+| `make ci-local` / QA green | `make qa` + clippy/tests as in verification report | Pass |
+| Output byte-identical to pre-A | SHA-256: 72/72 match | Pass |
+| No behaviour change for existing books | Directory-walk path unchanged; `"Guide"` section retained for A | Pass |
+| Preprocess seam ready for P2 | Identity function called before mdast parse | Pass |
+
+## User-visible behaviour
+
+None intended. Users building with `-i/-o` see the same HTML, sidebar, prev/next, and assets as before.
+
+## Deferred product validation
+
+- Structural SUMMARY-driven navigation → Increment B  
+- CLI subcommands → Increment C  
+- Relocatable/offline output → Increment D  
+- Themes/print → Increment E  
+
+## Sign-off
+
+Automated gate evidence complete. Stakeholder UAT not required for a pure refactor with byte-identical output.

--- a/docs/verification/verification-report-mdbook-parity-a.md
+++ b/docs/verification/verification-report-mdbook-parity-a.md
@@ -1,0 +1,84 @@
+# Verification Report: mdBook parity Increment A
+
+**Date**: 2026-08-08  
+**UTC**: 09:57:29 UTC  
+**Change slug**: mdbook-parity-a  
+**Issue**: [terraphim/md-book#1](https://git.terraphim.cloud/terraphim/md-book/issues/1)  
+**Branch**: `task/1-pipeline-decomposition`  
+**Plan**: `docs/plans/mdbook-parity-implementation-plan.md` (Increment A)
+
+## Scope verified
+
+| Step | Description | Status |
+|------|-------------|--------|
+| A1 | Extract `collect` / `render` / `index` into `pipeline/` + `render/` | Pass |
+| A2 | Identity `preprocess` seam with unit tests | Pass |
+| A3 | Baseline build timing + byte-identical gate | Pass |
+
+## Checks run
+
+```text
+cargo fmt
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --lib --bins
+cargo test --test integration --features "tokio,search,syntax-highlighting"
+cargo test --test mdbook_compatibility
+cargo test --test mdbook_test_book
+make qa
+```
+
+### Results
+
+| Suite | Result |
+|-------|--------|
+| Unit (`--lib --bins`) | 33 passed, 1 ignored |
+| Integration `build_test` | 12 passed |
+| `mdbook_compatibility` | 5 passed |
+| `mdbook_test_book` | 8 passed |
+| Clippy `-D warnings` | Clean |
+| `make qa` | Clean |
+
+## Byte-identical gate
+
+Pre-A and post-A builds of:
+
+- `tests/assets/test_book_1`
+- `test_book_mdbook/src`
+
+compared via SHA-256 over all HTML/CSS/JS assets (excluding `pagefind/` and the hash manifest itself).
+
+```text
+match=72 diff=0 missing=0
+```
+
+Gate satisfied: output is byte-identical to the pre-A build.
+
+## A3 performance baseline
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Full build wall time, `test_book_mdbook` (31 pages) | **0.86 s real** | `cargo run` debug binary; Pagefind CLI absent |
+| User CPU | 0.35 s | |
+| Sys CPU | 0.17 s | |
+| Pagefind index | N/A | `pagefind` CLI not installed; step fails gracefully (pre-existing) |
+
+Later increments must stay within 10% of this wall time on the same corpus (plan target). Criterion `benches/pagefind_bench.rs` remains the Pagefind-specific bench; re-run when the CLI is available.
+
+## Traceability
+
+| Plan requirement | Evidence |
+|------------------|----------|
+| `core::build` is orchestration only | `src/core.rs` delegates to `pipeline::run_sync` (+ async `pipeline::index`) |
+| Stages: collect → preprocess → render → index | `src/pipeline/mod.rs` |
+| Preprocess identity | `src/pipeline/preprocess.rs` + 3 unit tests |
+| Markdown rendering extracted | `src/render/markdown.rs` |
+| HTML/Tera assembly extracted | `src/render/html.rs` |
+| Existing suite untouched in intent | All prior tests still pass (some relocated with their code) |
+
+## Out-of-scope guard
+
+Unrelated WIP (SEO description/canonical, browser-validation plans, `crates/`, template CSS tweaks) remains in `git stash` and was **not** committed on this branch.
+
+## Verdict
+
+**Pass** — Increment A ready for review and PR.

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,28 +1,13 @@
-use anyhow::{Context, Result};
+//! CLI args and build orchestration.
+//!
+//! Pipeline stages live in [`crate::pipeline`] and [`crate::render`].
+
+use anyhow::Result;
 use clap::Parser;
-use jiff::Zoned;
-
-use markdown::to_html_with_options;
 use serde::Serialize;
-use std::fs;
-use tera::{Context as TeraContext, Tera};
-use walkdir::WalkDir;
 
-use crate::config::{BookConfig, MarkdownFormat};
-use crate::pagefind_service::PagefindBuilder;
-use markdown::mdast::Node;
-use markdown::to_mdast;
-use std::collections::BTreeMap;
-use std::path::Path;
-use std::path::PathBuf;
-#[cfg(feature = "syntax-highlighting")]
-use syntect::highlighting::ThemeSet;
-#[cfg(feature = "syntax-highlighting")]
-use syntect::html::{ClassStyle, ClassedHTMLGenerator};
-#[cfg(feature = "syntax-highlighting")]
-use syntect::parsing::SyntaxSet;
-#[cfg(feature = "syntax-highlighting")]
-use syntect::util::LinesWithEndings;
+use crate::config::BookConfig;
+use crate::pipeline;
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
@@ -56,21 +41,6 @@ pub struct Args {
 }
 
 #[derive(Serialize, Debug, Clone)]
-struct PageData {
-    title: String,
-    content: String,
-    sections: Vec<Section>,
-    previous: Option<PageInfo>,
-    next: Option<PageInfo>,
-}
-
-#[derive(Serialize, Debug, Clone)]
-struct Section {
-    title: String,
-    pages: Vec<PageInfo>,
-}
-
-#[derive(Serialize, Debug, Clone)]
 pub struct PageInfo {
     pub title: String,
     pub path: String,
@@ -94,688 +64,19 @@ pub fn build(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()
 
 #[cfg(feature = "tokio")]
 async fn build_impl(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()> {
-    build_sync_impl(args, config, watch_enabled).await
+    pipeline::run_sync(args, config, watch_enabled)?;
+
+    #[cfg(all(feature = "search", feature = "tokio"))]
+    {
+        pipeline::index(&args.output).await?;
+    }
+
+    Ok(())
 }
 
 #[cfg(not(feature = "tokio"))]
 fn build_impl(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()> {
-    build_sync_impl_sync(args, config, watch_enabled)
-}
-
-#[cfg(feature = "tokio")]
-async fn build_sync_impl(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()> {
-    build_sync_impl_sync(args, config, watch_enabled)?;
-
-    // After generating HTML files, run Pagefind indexing if search feature is enabled
-    #[cfg(all(feature = "search", feature = "tokio"))]
-    {
-        match PagefindBuilder::new(PathBuf::from(&args.output)).await {
-            Ok(pagefind) => {
-                if let Err(e) = pagefind.build().await {
-                    eprintln!("Search indexing failed: {e}");
-                }
-            }
-            Err(e) => {
-                eprintln!("Failed to create search builder: {e}");
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn build_sync_impl_sync(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()> {
-    // Initialize Tera with configured templates directory
-    let mut tera = Tera::default();
-
-    // Add template files from the configured directory
-    let template_files = [
-        ("page", "page.html.tera"),
-        ("index", "index.html.tera"),
-        ("sidebar", "sidebar.html.tera"),
-        ("footer", "footer.html.tera"),
-        ("header", "header.html.tera"),
-    ];
-
-    for (name, file) in template_files {
-        let template_path = format!("{}/{}", config.paths.templates, file);
-        let template_content = if Path::new(&template_path).exists() {
-            fs::read_to_string(&template_path)
-                .with_context(|| format!("Failed to read template: {template_path}"))?
-        } else {
-            // Load default template content directly
-            match file {
-                "page.html.tera" => include_str!("templates/page.html.tera").to_string(),
-                "index.html.tera" => include_str!("templates/index.html.tera").to_string(),
-                "sidebar.html.tera" => include_str!("templates/sidebar.html.tera").to_string(),
-                "footer.html.tera" => include_str!("templates/footer.html.tera").to_string(),
-                "header.html.tera" => include_str!("templates/header.html.tera").to_string(),
-                _ => return Err(anyhow::anyhow!("Unknown template file: {}", file)),
-            }
-        };
-
-        tera.add_raw_template(name, &template_content)
-            .with_context(|| format!("Failed to add template: {name}"))?;
-    }
-
-    // Create output directory if it doesn't exist
-    fs::create_dir_all(&args.output)?;
-
-    // Copy static assets
-    copy_static_assets(&args.output, &config.paths.templates, config)?;
-
-    // Collect all pages first
-    let mut all_pages = Vec::new();
-    let mut section_map: BTreeMap<String, Vec<PageInfo>> = BTreeMap::new();
-    let mut root_pages: Vec<PageInfo> = Vec::new();
-
-    // First pass: collect all pages
-    let mut entries: Vec<_> = WalkDir::new(&args.input)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
-
-    // Sort entries by path to ensure consistent ordering
-    entries.sort_by_key(|e| e.path().to_path_buf());
-
-    for entry in &entries {
-        let rel_path = entry.path().strip_prefix(&args.input)?;
-        let parent_dir = rel_path.parent().and_then(|p| p.to_str()).unwrap_or("");
-
-        let content = fs::read_to_string(entry.path())?;
-        let page_info = PageInfo {
-            title: extract_title(&content).unwrap_or_else(|| {
-                entry.path().file_stem().map_or_else(
-                    || "Untitled".to_string(),
-                    |s| s.to_string_lossy().into_owned(),
-                )
-            }),
-            path: format!("/{}", rel_path.with_extension("html").display()),
-        };
-
-        all_pages.push(page_info.clone());
-
-        if parent_dir.is_empty() {
-            root_pages.push(page_info);
-        } else {
-            section_map
-                .entry(parent_dir.to_string())
-                .or_default()
-                .push(page_info);
-        }
-    }
-
-    // Convert the map to sections
-    let mut sections = Vec::new();
-
-    // Add root pages first if they exist
-    if !root_pages.is_empty() {
-        sections.push(Section {
-            title: "Guide".to_string(),
-            pages: root_pages,
-        });
-    }
-
-    // Add other sections
-    for (title, pages) in section_map {
-        sections.push(Section { title, pages });
-    }
-
-    let total_pages = all_pages.len();
-    println!("Total pages: {total_pages}");
-
-    // Get current year using Jiff
-    let current_year = Zoned::now().year().to_string();
-
-    // Initialize syntax highlighting if feature is enabled
-    #[cfg(feature = "syntax-highlighting")]
-    let ss = SyntaxSet::load_defaults_newlines();
-
-    #[cfg(feature = "syntax-highlighting")]
-    {
-        // Add syntax highlighting CSS
-        let ts = ThemeSet::load_defaults();
-        // TODO: Make this configurable
-        let theme = &ts.themes["Solarized (light)"];
-        let syntax_css = syntect::html::css_for_theme_with_class_style(theme, ClassStyle::Spaced)
-            .map_err(|e| anyhow::anyhow!("CSS generation error: {:?}", e))?;
-
-        fs::write(format!("{}/css/syntax.css", args.output), syntax_css)?;
-    }
-
-    // Process each markdown file
-    for (current_page, entry) in entries.iter().enumerate() {
-        if entry.path().extension().is_some_and(|ext| ext == "md") {
-            let rel_path = entry.path().strip_prefix(&args.input)?;
-            let html_path = format!(
-                "{}/{}",
-                args.output,
-                rel_path.with_extension("html").display()
-            );
-
-            if let Some(parent) = Path::new(&html_path).parent() {
-                fs::create_dir_all(parent)?;
-            }
-
-            let markdown_content = fs::read_to_string(entry.path())?;
-            #[cfg(feature = "syntax-highlighting")]
-            let html_content = convert_md_links_to_html(&process_markdown_with_highlighting(
-                &markdown_content,
-                &ss,
-                config,
-            )?);
-            #[cfg(not(feature = "syntax-highlighting"))]
-            let html_content =
-                convert_md_links_to_html(&process_markdown_basic(&markdown_content, config)?);
-
-            let previous = if current_page > 0 {
-                Some(all_pages[current_page - 1].clone())
-            } else {
-                None
-            };
-
-            let next = if current_page + 1 < total_pages {
-                Some(all_pages[current_page + 1].clone())
-            } else {
-                None
-            };
-
-            let page_data = PageData {
-                title: extract_title(&markdown_content).unwrap_or_else(|| {
-                    entry
-                        .path()
-                        .file_stem()
-                        .map(|s| s.to_string_lossy().into_owned())
-                        .unwrap_or_else(|| "Untitled".to_string())
-                }),
-                content: html_content,
-                sections: sections.clone(),
-                previous,
-                next,
-            };
-
-            let mut context = TeraContext::new();
-            context.insert("year", &current_year);
-            context.insert("page", &page_data);
-            context.insert("config", &config);
-            context.insert(
-                "current_path",
-                &rel_path.with_extension("html").display().to_string(),
-            );
-            context.insert("watch_enabled", &watch_enabled);
-
-            let rendered = tera
-                .render("page", &context)
-                .with_context(|| format!("Failed to render page: {}", html_path))?;
-            fs::write(&html_path, rendered)
-                .with_context(|| format!("Failed to write file: {}", html_path))?;
-        }
-    }
-
-    // Generate index page
-    let mut context = TeraContext::new();
-    context.insert("year", &current_year);
-    context.insert("config", &config);
-    context.insert("sections", &sections);
-    context.insert("current_path", &"index.html");
-
-    let index_page = all_pages.iter().find(|p| p.path == "/index.html");
-
-    if let Some(index) = index_page {
-        // If index.md exists, use its content
-        let index_path = Path::new(&args.input).join("index.md");
-        let markdown_content = fs::read_to_string(&index_path)
-            .with_context(|| format!("Failed to read index file: {}", index_path.display()))?;
-        #[cfg(feature = "syntax-highlighting")]
-        let html_content = convert_md_links_to_html(&process_markdown_with_highlighting(
-            &markdown_content,
-            &ss,
-            config,
-        )?);
-        #[cfg(not(feature = "syntax-highlighting"))]
-        let html_content =
-            convert_md_links_to_html(&process_markdown_basic(&markdown_content, config)?);
-
-        context.insert("has_index", &true);
-        context.insert("title", &index.title);
-        context.insert("content", &html_content);
-    } else {
-        // If no index.md, use the default template with cards
-        context.insert("has_index", &false);
-        context.insert("title", &"Documentation");
-    }
-
-    let rendered = tera
-        .render("index", &context)
-        .context("Failed to render index page")?;
-    fs::write(format!("{}/index.html", args.output), rendered)
-        .context("Failed to write index.html")?;
-
-    // Search indexing handled in async wrapper or skipped
-    #[cfg(not(all(feature = "search", feature = "tokio")))]
-    {
-        println!("Skipping search indexing (search or tokio feature not enabled)");
-    }
-
-    Ok(())
-}
-
-fn extract_title(markdown: &str) -> Option<String> {
-    markdown
-        .lines()
-        .find(|line| line.starts_with("# "))
-        .map(|line| line[2..].trim().to_string())
-}
-
-fn copy_static_assets(output_dir: &str, templates_dir: &str, _config: &BookConfig) -> Result<()> {
-    // Create components directory
-    fs::create_dir_all(format!("{}/components", output_dir))?;
-
-    // Copy CSS directory
-    let css_source = format!("{}/css", templates_dir);
-    let css_dest = format!("{}/css/", output_dir);
-    fs::create_dir_all(&css_dest)?;
-    if std::path::Path::new(&css_source).exists() {
-        for entry in WalkDir::new(&css_source) {
-            let entry = entry?;
-            let dest_path = css_dest.clone()
-                + entry
-                    .path()
-                    .strip_prefix(&css_source)?
-                    .to_str()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Invalid UTF-8 in CSS path: {:?}", entry.path())
-                    })?;
-            if entry.file_type().is_file() {
-                fs::copy(entry.path(), dest_path)?;
-            }
-        }
-    }
-
-    // Copy JS directory
-    let js_source = format!("{}/js", templates_dir);
-    let js_dest = format!("{}/js/", output_dir);
-    fs::create_dir_all(&js_dest)?;
-    if std::path::Path::new(&js_source).exists() {
-        for entry in WalkDir::new(&js_source) {
-            let entry = entry?;
-            let dest_path = js_dest.clone()
-                + entry
-                    .path()
-                    .strip_prefix(&js_source)?
-                    .to_str()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Invalid UTF-8 in JS path: {:?}", entry.path())
-                    })?;
-            if entry.file_type().is_file() {
-                fs::copy(entry.path(), dest_path)?;
-            }
-        }
-    }
-    // Copy img directory from templates
-    let img_source = format!("{}/img", templates_dir);
-    let img_dest = format!("{}/img/", output_dir);
-    fs::create_dir_all(&img_dest)?;
-    if std::path::Path::new(&img_source).exists() {
-        for entry in WalkDir::new(&img_source) {
-            let entry = entry?;
-            let dest_path = img_dest.clone()
-                + entry
-                    .path()
-                    .strip_prefix(&img_source)?
-                    .to_str()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Invalid UTF-8 in image path: {:?}", entry.path())
-                    })?;
-            if entry.file_type().is_file() {
-                fs::copy(entry.path(), dest_path)
-                    .context(format!("Failed to copy img file: {:?}", entry.path()))?;
-            }
-        }
-    }
-
-    fs::write(
-        format!("{}/components/doc-toc.js", output_dir),
-        include_str!("templates/components/doc-toc.js"),
-    )
-    .context("Failed to write TOC component")?;
-
-    fs::write(
-        format!("{}/components/simple-block.js", output_dir),
-        include_str!("templates/components/simple-block.js"),
-    )
-    .context("Failed to write Simple Block component")?;
-
-    fs::write(
-        format!("{}/components/search-modal.js", output_dir),
-        include_str!("templates/components/search-modal.js"),
-    )
-    .context("Failed to write Search Modal component")?;
-
-    Ok(())
-}
-
-#[cfg(feature = "syntax-highlighting")]
-fn process_code_block(code: &str, language: Option<&str>, ss: &SyntaxSet) -> Result<String> {
-    let syntax = match language {
-        Some("rust") => {
-            let syntax = ss
-                .find_syntax_by_extension("rs")
-                .ok_or_else(|| anyhow::anyhow!("Rust syntax not found"))?;
-            // Check if code block has editable tag
-            if code.contains("<--editable-->") {
-                let code_with_comment = format!("{}\n// <--editable-->", code);
-                process_rust_code(&code_with_comment, syntax, ss)?
-            } else {
-                process_rust_code(code, syntax, ss)?
-            }
-        }
-        Some("mermaid") => {
-            // For markdown, preserve the content exactly as is
-            format!(
-                "<pre class=\"code\"><code class=\"language-mermaid\">{}</code></pre>",
-                html_escape::encode_text(code)
-            )
-        }
-        Some(lang) => {
-            let syntax = ss
-                .find_syntax_by_extension(lang)
-                .or_else(|| ss.find_syntax_by_name(lang))
-                .or_else(|| ss.find_syntax_by_token(lang))
-                .or_else(|| Some(ss.find_syntax_plain_text()))
-                .ok_or_else(|| anyhow::anyhow!("Syntax not found for language: {:?}", lang))?;
-            process_generic_code(code, syntax, ss)?
-        }
-        None => {
-            let syntax = ss.find_syntax_plain_text();
-            process_generic_code(code, syntax, ss)?
-        }
-    };
-    Ok(syntax)
-}
-
-#[cfg(feature = "syntax-highlighting")]
-fn process_rust_code(
-    code: &str,
-    syntax: &syntect::parsing::SyntaxReference,
-    ss: &SyntaxSet,
-) -> Result<String> {
-    let mut html_generator =
-        ClassedHTMLGenerator::new_with_class_style(syntax, ss, ClassStyle::Spaced);
-
-    for line in LinesWithEndings::from(code) {
-        html_generator
-            .parse_html_for_line_which_includes_newline(line)
-            .map_err(|e| anyhow::anyhow!("HTML generation error: {:?}", e))?;
-    }
-    let html = html_generator.finalize();
-    Ok(format!(
-        "<pre class=\"code rust\"><code>{}</code></pre>",
-        html
-    ))
-}
-
-#[cfg(feature = "syntax-highlighting")]
-fn process_generic_code(
-    code: &str,
-    syntax: &syntect::parsing::SyntaxReference,
-    ss: &SyntaxSet,
-) -> Result<String> {
-    let mut html_generator =
-        ClassedHTMLGenerator::new_with_class_style(syntax, ss, ClassStyle::Spaced);
-
-    for line in LinesWithEndings::from(code) {
-        html_generator
-            .parse_html_for_line_which_includes_newline(line)
-            .map_err(|e| anyhow::anyhow!("HTML generation error: {:?}", e))?;
-    }
-    let html = html_generator.finalize();
-    Ok(format!("<pre class=\"code\"><code>{}</code></pre>", html))
-}
-
-/// Converts internal .md links to .html links in HTML content.
-/// This ensures that links like `href="page.md"` become `href="page.html"`.
-/// External links (http://, https://, mailto:, etc.) are not modified.
-fn convert_md_links_to_html(html: &str) -> String {
-    let mut result = html.to_string();
-
-    // Convert href="...md" to href="...html" (double quotes)
-    // We need to be careful to only convert internal links, not external ones
-    let mut start = 0;
-    while let Some(href_pos) = result[start..].find("href=\"") {
-        let abs_pos = start + href_pos;
-        let url_start = abs_pos + 6; // Position after 'href="'
-
-        if let Some(quote_end) = result[url_start..].find('"') {
-            let url_end = url_start + quote_end;
-            let url = &result[url_start..url_end];
-
-            // Only convert if it's an internal link ending with .md
-            // Skip external links (http://, https://, mailto:, //, etc.)
-            if url.ends_with(".md")
-                && !url.starts_with("http://")
-                && !url.starts_with("https://")
-                && !url.starts_with("mailto:")
-                && !url.starts_with("//")
-            {
-                // Replace .md with .html
-                let new_url = format!("{}.html", &url[..url.len() - 3]);
-                result = format!(
-                    "{}href=\"{}\"{}",
-                    &result[..abs_pos],
-                    new_url,
-                    &result[url_end + 1..]
-                );
-                start = abs_pos + 6 + new_url.len() + 1;
-            } else {
-                start = url_end + 1;
-            }
-        } else {
-            break;
-        }
-    }
-
-    // Also handle single quotes (less common but possible)
-    start = 0;
-    while let Some(href_pos) = result[start..].find("href='") {
-        let abs_pos = start + href_pos;
-        let url_start = abs_pos + 6; // Position after "href='"
-
-        if let Some(quote_end) = result[url_start..].find('\'') {
-            let url_end = url_start + quote_end;
-            let url = &result[url_start..url_end];
-
-            if url.ends_with(".md")
-                && !url.starts_with("http://")
-                && !url.starts_with("https://")
-                && !url.starts_with("mailto:")
-                && !url.starts_with("//")
-            {
-                let new_url = format!("{}.html", &url[..url.len() - 3]);
-                result = format!(
-                    "{}href='{}'{}",
-                    &result[..abs_pos],
-                    new_url,
-                    &result[url_end + 1..]
-                );
-                start = abs_pos + 6 + new_url.len() + 1;
-            } else {
-                start = url_end + 1;
-            }
-        } else {
-            break;
-        }
-    }
-
-    result
-}
-
-#[cfg(feature = "syntax-highlighting")]
-fn process_markdown_with_highlighting(
-    content: &str,
-    ss: &SyntaxSet,
-    config: &BookConfig,
-) -> Result<String> {
-    let parse_options = match config.markdown.format {
-        MarkdownFormat::Mdx => markdown::ParseOptions::mdx(),
-        MarkdownFormat::Gfm => markdown::ParseOptions::gfm(),
-        MarkdownFormat::Markdown => markdown::ParseOptions::default(),
-    };
-
-    let compile_options = if matches!(config.markdown.format, MarkdownFormat::Gfm) {
-        markdown::CompileOptions::gfm()
-    } else {
-        markdown::CompileOptions::default()
-    };
-
-    let mut options = markdown::Options {
-        parse: parse_options,
-        compile: compile_options,
-    };
-
-    // Modify constructs for HTML and frontmatter
-    options.parse.constructs.frontmatter = config.markdown.frontmatter;
-    options.parse.constructs.html_flow = config.output.html.allow_html;
-    options.parse.constructs.html_text = config.output.html.allow_html;
-    options.compile.allow_dangerous_html = config.output.html.allow_html;
-    options.compile.allow_dangerous_protocol = config.output.html.allow_html;
-
-    let ast = to_mdast(content, &options.parse)
-        .map_err(|e| anyhow::anyhow!("Markdown parsing error: {:?}", e))?;
-
-    let mut parts = Vec::new();
-    let mut last_pos = 0;
-
-    fn process_node(
-        node: &Node,
-        ss: &SyntaxSet,
-        content: &str,
-        parts: &mut Vec<String>,
-        last_pos: &mut usize,
-        config: &BookConfig,
-    ) -> Result<()> {
-        match node {
-            Node::Code(code) => {
-                if let Some(pos) = &code.position {
-                    if *last_pos < pos.start.offset {
-                        let text = &content[*last_pos..pos.start.offset];
-                        if !text.trim().is_empty() {
-                            let parse_options = match config.markdown.format {
-                                MarkdownFormat::Mdx => markdown::ParseOptions::mdx(),
-                                MarkdownFormat::Gfm => markdown::ParseOptions::gfm(),
-                                MarkdownFormat::Markdown => markdown::ParseOptions::default(),
-                            };
-
-                            let compile_options =
-                                if matches!(config.markdown.format, MarkdownFormat::Gfm) {
-                                    markdown::CompileOptions::gfm()
-                                } else {
-                                    markdown::CompileOptions::default()
-                                };
-
-                            let mut options = markdown::Options {
-                                parse: parse_options,
-                                compile: compile_options,
-                            };
-
-                            options.parse.constructs.frontmatter = config.markdown.frontmatter;
-                            options.parse.constructs.html_flow = config.output.html.allow_html;
-                            options.parse.constructs.html_text = config.output.html.allow_html;
-                            options.compile.allow_dangerous_html = config.output.html.allow_html;
-                            options.compile.allow_dangerous_protocol =
-                                config.output.html.allow_html;
-
-                            let temp_html = to_html_with_options(text, &options).map_err(|e| {
-                                anyhow::anyhow!("Markdown conversion error: {:?}", e)
-                            })?;
-                            parts.push(temp_html);
-                        }
-                    }
-
-                    let highlighted = process_code_block(&code.value, code.lang.as_deref(), ss)?;
-                    parts.push(highlighted);
-
-                    *last_pos = pos.end.offset;
-                }
-            }
-            _ => {
-                if let Some(children) = node.children() {
-                    for child in children {
-                        process_node(child, ss, content, parts, last_pos, config)?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    process_node(&ast, ss, content, &mut parts, &mut last_pos, config)?;
-
-    if last_pos < content.len() {
-        let remaining = &content[last_pos..];
-        if !remaining.trim().is_empty() {
-            let parse_options = match config.markdown.format {
-                MarkdownFormat::Mdx => markdown::ParseOptions::mdx(),
-                MarkdownFormat::Gfm => markdown::ParseOptions::gfm(),
-                MarkdownFormat::Markdown => markdown::ParseOptions::default(),
-            };
-
-            let compile_options = if matches!(config.markdown.format, MarkdownFormat::Gfm) {
-                markdown::CompileOptions::gfm()
-            } else {
-                markdown::CompileOptions::default()
-            };
-
-            let mut options = markdown::Options {
-                parse: parse_options,
-                compile: compile_options,
-            };
-
-            options.parse.constructs.frontmatter = config.markdown.frontmatter;
-            options.parse.constructs.html_flow = config.output.html.allow_html;
-            options.parse.constructs.html_text = config.output.html.allow_html;
-            options.compile.allow_dangerous_html = config.output.html.allow_html;
-            options.compile.allow_dangerous_protocol = config.output.html.allow_html;
-
-            parts.push(
-                to_html_with_options(remaining, &options)
-                    .map_err(|e| anyhow::anyhow!("Markdown conversion error: {:?}", e))?,
-            );
-        }
-    }
-
-    Ok(parts.join(""))
-}
-
-#[cfg(not(feature = "syntax-highlighting"))]
-fn process_markdown_basic(content: &str, config: &BookConfig) -> Result<String> {
-    let parse_options = match config.markdown.format {
-        MarkdownFormat::Mdx => markdown::ParseOptions::mdx(),
-        MarkdownFormat::Gfm => markdown::ParseOptions::gfm(),
-        MarkdownFormat::Markdown => markdown::ParseOptions::default(),
-    };
-
-    let compile_options = if matches!(config.markdown.format, MarkdownFormat::Gfm) {
-        markdown::CompileOptions::gfm()
-    } else {
-        markdown::CompileOptions::default()
-    };
-
-    let mut options = markdown::Options {
-        parse: parse_options,
-        compile: compile_options,
-    };
-
-    // Modify constructs for HTML and frontmatter
-    options.parse.constructs.frontmatter = config.markdown.frontmatter;
-    options.parse.constructs.html_flow = config.output.html.allow_html;
-    options.parse.constructs.html_text = config.output.html.allow_html;
-    options.compile.allow_dangerous_html = config.output.html.allow_html;
-    options.compile.allow_dangerous_protocol = config.output.html.allow_html;
-
-    to_html_with_options(content, &options)
-        .map_err(|e| anyhow::anyhow!("Markdown conversion error: {:?}", e))
+    pipeline::run_sync(args, config, watch_enabled)
 }
 
 #[cfg(test)]
@@ -785,104 +86,10 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    // Get project root directory (CARGO_MANIFEST_DIR) for absolute path resolution
-    fn project_root() -> std::path::PathBuf {
-        std::path::PathBuf::from(
-            std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
-        )
-    }
-
-    #[test]
-    fn test_extract_title_h1() {
-        let markdown = "# Main Title\n\nSome content here.";
-        let title = extract_title(markdown);
-        assert_eq!(title, Some("Main Title".to_string()));
-    }
-
-    #[test]
-    fn test_extract_title_h2() {
-        let markdown = "Some text\n\n## Section Title\n\nContent";
-        let title = extract_title(markdown);
-        // extract_title only looks for H1 headings, not H2
-        assert_eq!(title, None);
-    }
-
-    #[test]
-    fn test_extract_title_no_heading() {
-        let markdown = "Just some regular text without headings.";
-        let title = extract_title(markdown);
-        assert_eq!(title, None);
-    }
-
-    #[test]
-    fn test_extract_title_complex_markup() {
-        let markdown = "# Title with **bold** and *italic*";
-        let title = extract_title(markdown);
-        assert_eq!(title, Some("Title with **bold** and *italic*".to_string()));
-    }
-
-    #[test]
-    fn test_extract_title_first_heading_wins() {
-        let markdown = "# First Title\n\n## Second Title\n\n# Third Title";
-        let title = extract_title(markdown);
-        assert_eq!(title, Some("First Title".to_string()));
-    }
-
-    #[test]
-    fn test_convert_md_links_to_html() {
-        // Test basic .md to .html conversion
-        let html = r#"<a href="page.md">Link</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(result, r#"<a href="page.html">Link</a>"#);
-
-        // Test nested path
-        let html = r#"<a href="dir/subdir/page.md">Link</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(result, r#"<a href="dir/subdir/page.html">Link</a>"#);
-
-        // Test multiple links
-        let html = r#"<a href="page1.md">Link1</a> and <a href="page2.md">Link2</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(
-            result,
-            r#"<a href="page1.html">Link1</a> and <a href="page2.html">Link2</a>"#
-        );
-
-        // Test that external links are NOT converted
-        let html = r#"<a href="https://example.com/page.md">External</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(
-            result,
-            r#"<a href="https://example.com/page.md">External</a>"#
-        );
-
-        // Test http:// links are not converted
-        let html = r#"<a href="http://example.com/page.md">External</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(
-            result,
-            r#"<a href="http://example.com/page.md">External</a>"#
-        );
-
-        // Test that .html links are not modified
-        let html = r#"<a href="page.html">Link</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(result, r#"<a href="page.html">Link</a>"#);
-
-        // Test mixed internal and external links
-        let html = r#"<a href="local.md">Local</a> and <a href="https://ext.com/file.md">Ext</a>"#;
-        let result = convert_md_links_to_html(html);
-        assert_eq!(
-            result,
-            r#"<a href="local.html">Local</a> and <a href="https://ext.com/file.md">Ext</a>"#
-        );
-    }
-
     #[test]
     fn test_args_default_values() {
         use clap::Parser;
 
-        // Test that we can parse minimal required args
         let args = Args::try_parse_from(["md-book", "-i", "input", "-o", "output"]).unwrap();
         assert_eq!(args.input, "input");
         assert_eq!(args.output, "output");
@@ -912,99 +119,6 @@ mod tests {
         assert_eq!(args.port, 8080);
     }
 
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_default() -> Result<()> {
-        let config = BookConfig::default();
-        let markdown = "# Hello World\n\nThis is **bold** text.";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        assert!(html.contains("<h1>Hello World</h1>"));
-        assert!(html.contains("<strong>bold</strong>"));
-
-        Ok(())
-    }
-
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_gfm() -> Result<()> {
-        let mut config = BookConfig::default();
-        config.markdown.format = MarkdownFormat::Gfm;
-
-        let markdown = "# GFM Test\n\n~~strikethrough~~\n\n- [ ] Task item";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        assert!(html.contains("<h1>GFM Test</h1>"));
-        assert!(html.contains("strikethrough"));
-
-        Ok(())
-    }
-
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_mdx() -> Result<()> {
-        let mut config = BookConfig::default();
-        config.markdown.format = MarkdownFormat::Mdx;
-
-        let markdown = "# MDX Test\n\nThis is **bold** text.";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        assert!(html.contains("<h1>MDX Test</h1>"));
-        assert!(html.contains("<strong>bold</strong>"));
-
-        Ok(())
-    }
-
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_with_html_allowed() -> Result<()> {
-        let mut config = BookConfig::default();
-        config.output.html.allow_html = true;
-
-        let markdown = "# Test\n\n<div>Raw HTML</div>";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        assert!(html.contains("<div>Raw HTML</div>"));
-
-        Ok(())
-    }
-
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_with_html_disallowed() -> Result<()> {
-        let config = BookConfig::default();
-
-        let markdown = "# Test\n\n<div>Raw HTML</div>";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        // HTML should be escaped or stripped when not allowed
-        assert!(!html.contains("<div>Raw HTML</div>"));
-
-        Ok(())
-    }
-
-    #[cfg(not(feature = "syntax-highlighting"))]
-    #[test]
-    fn test_process_markdown_basic_with_frontmatter() -> Result<()> {
-        let mut config = BookConfig::default();
-        config.markdown.frontmatter = true;
-
-        let markdown = "---\ntitle: Test\n---\n\n# Hello World";
-
-        let html = process_markdown_basic(markdown, &config)?;
-
-        assert!(html.contains("<h1>Hello World</h1>"));
-        // Frontmatter should be processed/removed from output
-        assert!(!html.contains("---"));
-
-        Ok(())
-    }
-
     #[test]
     #[ignore = "MathJax support not implemented yet"]
     fn test_process_markdown_with_mathjax() -> Result<()> {
@@ -1012,116 +126,9 @@ mod tests {
         config.output.html.mathjax_support = true;
 
         let markdown = "# Math Test\n\n$$E = mc^2$$";
-
-        // Test with basic markdown processing (will work regardless of syntax highlighting feature)
         let html = markdown::to_html(markdown);
-
-        // When implemented, should contain MathJax markup
         assert!(html.contains("E = mc^2"));
-
         Ok(())
-    }
-
-    #[test]
-    fn test_page_data_serialization() -> Result<()> {
-        let page_data = PageData {
-            title: "Test Page".to_string(),
-            content: "<h1>Test</h1>".to_string(),
-            sections: vec![Section {
-                title: "Section 1".to_string(),
-                pages: vec![PageInfo {
-                    title: "Page 1".to_string(),
-                    path: "/page1".to_string(),
-                }],
-            }],
-            previous: Some(PageInfo {
-                title: "Previous".to_string(),
-                path: "/prev".to_string(),
-            }),
-            next: None,
-        };
-
-        let serialized = serde_json::to_string(&page_data)?;
-        assert!(serialized.contains("Test Page"));
-        assert!(serialized.contains("Section 1"));
-        assert!(serialized.contains("/page1"));
-
-        Ok(())
-    }
-
-    #[cfg(feature = "syntax-highlighting")]
-    #[test]
-    fn test_process_code_block_rust() -> Result<()> {
-        use syntect::parsing::SyntaxSet;
-
-        let ss = SyntaxSet::load_defaults_newlines();
-        let code = "fn main() {\n    println!(\"Hello, world!\");\n}";
-
-        let highlighted = process_code_block(code, Some("rust"), &ss)?;
-
-        assert!(highlighted.contains("<pre"));
-        // Syntax highlighting behavior may vary, just check basic structure
-        assert!(!highlighted.is_empty());
-
-        Ok(())
-    }
-
-    #[cfg(feature = "syntax-highlighting")]
-    #[test]
-    fn test_process_code_block_no_language() -> Result<()> {
-        use syntect::parsing::SyntaxSet;
-
-        let ss = SyntaxSet::load_defaults_newlines();
-        let code = "some plain text code";
-
-        let highlighted = process_code_block(code, None, &ss)?;
-
-        assert!(highlighted.contains("<pre"));
-        assert!(highlighted.contains("some plain text code"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_copy_static_assets() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let output_dir = temp_dir.path().join("output");
-        // Use absolute path to avoid issues when other tests change working directory
-        let templates_dir = project_root().join("src/templates");
-
-        fs::create_dir_all(&output_dir)?;
-
-        let config = BookConfig::default();
-        copy_static_assets(
-            output_dir.to_str().unwrap(),
-            templates_dir.to_str().unwrap(),
-            &config,
-        )?;
-
-        // Check that some assets were copied (if templates exist)
-        let _has_assets = output_dir.join("css").exists()
-            || output_dir.join("js").exists()
-            || output_dir.join("img").exists();
-
-        // This test passes even if no assets exist, just checking the function doesn't crash
-        assert!(output_dir.exists());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_copy_static_assets_nonexistent_dir() {
-        let temp_dir = TempDir::new().unwrap();
-        let output_dir = temp_dir.path().join("output");
-        let templates_dir = "nonexistent_templates";
-
-        fs::create_dir_all(&output_dir).unwrap();
-
-        let config = BookConfig::default();
-        let result = copy_static_assets(output_dir.to_str().unwrap(), templates_dir, &config);
-
-        // Should not fail even if templates dir doesn't exist
-        assert!(result.is_ok());
     }
 
     // WASM-specific tests
@@ -1135,8 +142,6 @@ mod tests {
 
         assert!(html.contains("<h1>WASM Test</h1>"));
         assert!(html.contains("<strong>bold</strong>"));
-
-        // WASM should handle basic markdown correctly
         assert!(!html.is_empty());
     }
 
@@ -1157,13 +162,11 @@ mod tests {
         let markdown = "```rust\nfn main() {\n    println!(\"Hello, WASM!\");\n}\n```";
         let html = wasm_process_markdown(markdown);
 
-        // WASM should handle code blocks (even without syntax highlighting)
         assert!(html.contains("<pre>") || html.contains("<code>"));
         assert!(html.contains("fn main"));
         assert!(html.contains("Hello, WASM!"));
     }
 
-    // Integration-style test for build function
     #[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
     #[tokio::test]
     async fn test_build_simple_book() -> Result<()> {
@@ -1174,7 +177,6 @@ mod tests {
         fs::create_dir_all(&input_dir)?;
         fs::create_dir_all(&output_dir)?;
 
-        // Create simple markdown file
         fs::write(input_dir.join("test.md"), "# Test Page\n\nThis is a test.")?;
 
         let args = Args {
@@ -1192,9 +194,7 @@ mod tests {
         let config = BookConfig::default();
         build(&args, &config, false).await?;
 
-        // Verify output was created
         assert!(output_dir.exists());
-
         Ok(())
     }
 
@@ -1208,7 +208,6 @@ mod tests {
         fs::create_dir_all(&input_dir)?;
         fs::create_dir_all(&output_dir)?;
 
-        // Create simple markdown file
         fs::write(input_dir.join("test.md"), "# Test Page\n\nThis is a test.")?;
 
         let args = Args {
@@ -1226,9 +225,7 @@ mod tests {
         let config = BookConfig::default();
         build(&args, &config, false)?;
 
-        // Verify output was created
         assert!(output_dir.exists());
-
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod config;
 pub mod core;
 pub mod pagefind_service;
+pub mod pipeline;
+pub mod render;
 
 // Optional server module for native builds only
 #[cfg(feature = "server")]

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,0 +1,235 @@
+//! Build pipeline: `collect` → `preprocess` → `render` → `index`.
+//!
+//! Increment A extracts the stages from the former monolithic `build_sync_impl_sync`
+//! with zero behaviour change. Later increments target a single stage.
+
+pub mod preprocess;
+
+use anyhow::{Context, Result};
+use jiff::Zoned;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::{DirEntry, WalkDir};
+
+use crate::config::BookConfig;
+use crate::core::{Args, PageInfo};
+use crate::pipeline::preprocess::{preprocess, PreprocessCtx};
+use crate::render::html::{
+    copy_static_assets, extract_title, init_tera, render_index, render_page, write_syntax_css,
+    Section,
+};
+use crate::render::markdown::render_markdown;
+
+/// Collected book structure before rendering (directory-walk mode).
+///
+/// Increment B replaces this with the `Book` model when `SUMMARY.md` is present.
+#[derive(Debug, Clone)]
+pub struct CollectedPages {
+    /// Markdown source entries in path-sorted order (prev/next basis today).
+    pub entries: Vec<DirEntry>,
+    /// Flat page list in the same order as `entries`.
+    pub all_pages: Vec<PageInfo>,
+    /// Sidebar sections derived from parent directories.
+    pub sections: Vec<Section>,
+}
+
+/// Run the synchronous pipeline stages: collect → render (with preprocess).
+///
+/// Indexing stays in the async wrapper in `core` when the search feature is on.
+pub fn run_sync(args: &Args, config: &BookConfig, watch_enabled: bool) -> Result<()> {
+    let tera = init_tera(config)?;
+    fs::create_dir_all(&args.output)?;
+    copy_static_assets(&args.output, &config.paths.templates, config)?;
+
+    let collected = collect(&args.input)?;
+    println!("Total pages: {}", collected.all_pages.len());
+
+    let current_year = Zoned::now().year().to_string();
+
+    #[cfg(feature = "syntax-highlighting")]
+    let ss = {
+        use syntect::parsing::SyntaxSet;
+        let ss = SyntaxSet::load_defaults_newlines();
+        write_syntax_css(&args.output)?;
+        ss
+    };
+
+    let preprocess_ctx = PreprocessCtx;
+
+    // Render each chapter
+    for (current_page, entry) in collected.entries.iter().enumerate() {
+        if !entry.path().extension().is_some_and(|ext| ext == "md") {
+            continue;
+        }
+
+        let rel_path = entry.path().strip_prefix(&args.input)?;
+        let html_path = format!(
+            "{}/{}",
+            args.output,
+            rel_path.with_extension("html").display()
+        );
+
+        if let Some(parent) = Path::new(&html_path).parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let markdown_content = fs::read_to_string(entry.path())?;
+        let preprocessed = preprocess(&markdown_content, &preprocess_ctx)?;
+
+        #[cfg(feature = "syntax-highlighting")]
+        let html_content = render_markdown(&preprocessed, config, Some(&ss))?;
+        #[cfg(not(feature = "syntax-highlighting"))]
+        let html_content = render_markdown(&preprocessed, config, None)?;
+
+        let previous = if current_page > 0 {
+            Some(collected.all_pages[current_page - 1].clone())
+        } else {
+            None
+        };
+
+        let next = if current_page + 1 < collected.all_pages.len() {
+            Some(collected.all_pages[current_page + 1].clone())
+        } else {
+            None
+        };
+
+        let title = extract_title(&markdown_content).unwrap_or_else(|| {
+            entry
+                .path()
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "Untitled".to_string())
+        });
+
+        render_page(
+            &tera,
+            &html_path,
+            title,
+            html_content,
+            &collected.sections,
+            previous,
+            next,
+            &current_year,
+            config,
+            &rel_path.with_extension("html").display().to_string(),
+            watch_enabled,
+        )?;
+    }
+
+    // Index page
+    let index_page = collected.all_pages.iter().find(|p| p.path == "/index.html");
+
+    let index_content = if index_page.is_some() {
+        let index_path = Path::new(&args.input).join("index.md");
+        let markdown_content = fs::read_to_string(&index_path)
+            .with_context(|| format!("Failed to read index file: {}", index_path.display()))?;
+        let preprocessed = preprocess(&markdown_content, &preprocess_ctx)?;
+        #[cfg(feature = "syntax-highlighting")]
+        let html = render_markdown(&preprocessed, config, Some(&ss))?;
+        #[cfg(not(feature = "syntax-highlighting"))]
+        let html = render_markdown(&preprocessed, config, None)?;
+        Some(html)
+    } else {
+        None
+    };
+
+    render_index(
+        &tera,
+        &args.output,
+        index_page,
+        index_content,
+        &collected.sections,
+        &current_year,
+        config,
+    )?;
+
+    #[cfg(not(all(feature = "search", feature = "tokio")))]
+    {
+        println!("Skipping search indexing (search or tokio feature not enabled)");
+    }
+
+    Ok(())
+}
+
+/// Collect markdown pages by walking `input_dir`, sorting by path, grouping by parent.
+///
+/// This is today's directory-walk behaviour. Increment B moves it to
+/// `book::directory` and selects on `SUMMARY.md` presence.
+pub fn collect(input_dir: &str) -> Result<CollectedPages> {
+    let mut all_pages = Vec::new();
+    let mut section_map: BTreeMap<String, Vec<PageInfo>> = BTreeMap::new();
+    let mut root_pages: Vec<PageInfo> = Vec::new();
+
+    let mut entries: Vec<_> = WalkDir::new(input_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+
+    entries.sort_by_key(|e| e.path().to_path_buf());
+
+    for entry in &entries {
+        let rel_path = entry.path().strip_prefix(input_dir)?;
+        let parent_dir = rel_path.parent().and_then(|p| p.to_str()).unwrap_or("");
+
+        let content = fs::read_to_string(entry.path())?;
+        let page_info = PageInfo {
+            title: extract_title(&content).unwrap_or_else(|| {
+                entry.path().file_stem().map_or_else(
+                    || "Untitled".to_string(),
+                    |s| s.to_string_lossy().into_owned(),
+                )
+            }),
+            path: format!("/{}", rel_path.with_extension("html").display()),
+        };
+
+        all_pages.push(page_info.clone());
+
+        if parent_dir.is_empty() {
+            root_pages.push(page_info);
+        } else {
+            section_map
+                .entry(parent_dir.to_string())
+                .or_default()
+                .push(page_info);
+        }
+    }
+
+    let mut sections = Vec::new();
+
+    if !root_pages.is_empty() {
+        sections.push(Section {
+            title: "Guide".to_string(),
+            pages: root_pages,
+        });
+    }
+
+    for (title, pages) in section_map {
+        sections.push(Section { title, pages });
+    }
+
+    Ok(CollectedPages {
+        entries,
+        all_pages,
+        sections,
+    })
+}
+
+/// Run Pagefind indexing over the output directory (async path only).
+#[cfg(all(feature = "search", feature = "tokio"))]
+pub async fn index(output: &str) -> Result<()> {
+    use crate::pagefind_service::PagefindBuilder;
+
+    match PagefindBuilder::new(PathBuf::from(output)).await {
+        Ok(pagefind) => {
+            if let Err(e) = pagefind.build().await {
+                eprintln!("Search indexing failed: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to create search builder: {e}");
+        }
+    }
+    Ok(())
+}

--- a/src/pipeline/preprocess.rs
+++ b/src/pipeline/preprocess.rs
@@ -1,0 +1,51 @@
+//! Preprocessing stage — designated seam for mdBook-style directives.
+//!
+//! Today this is an identity function. P2 directives (`{{#include}}`,
+//! `{{#rustdoc_include}}`, `{{#playground}}`, hidden lines, etc.) land here
+//! in a later cycle without touching the collect/render stages.
+
+use anyhow::Result;
+
+/// Context available to preprocessors.
+///
+/// Empty for now; later increments may carry chapter path, book root, and
+/// config knobs that directives need.
+#[derive(Debug, Default, Clone)]
+pub struct PreprocessCtx;
+
+/// Identity preprocessor.
+///
+/// Called on every chapter's markdown text before mdast parsing. Must preserve
+/// input exactly until P2 lands — that is the Increment A contract.
+///
+/// # Errors
+///
+/// Never errors today; the `Result` is for future I/O-bound directives.
+pub fn preprocess(md: &str, _ctx: &PreprocessCtx) -> Result<String> {
+    Ok(md.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preprocess_identity_preserves_input() {
+        let input = "# Title\n\n{{#include foo.md}}\n\nSome text with **bold**.";
+        let out = preprocess(input, &PreprocessCtx).unwrap();
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn test_preprocess_identity_empty() {
+        let out = preprocess("", &PreprocessCtx).unwrap();
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_preprocess_identity_preserves_whitespace() {
+        let input = "  \n\t# A\n\n";
+        let out = preprocess(input, &PreprocessCtx).unwrap();
+        assert_eq!(out, input);
+    }
+}

--- a/src/render/html.rs
+++ b/src/render/html.rs
@@ -1,0 +1,364 @@
+//! HTML page assembly: Tera templates, static assets, page/index writers.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+use tera::{Context as TeraContext, Tera};
+use walkdir::WalkDir;
+
+use crate::config::BookConfig;
+use crate::core::PageInfo;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct PageData {
+    pub title: String,
+    pub content: String,
+    pub sections: Vec<Section>,
+    pub previous: Option<PageInfo>,
+    pub next: Option<PageInfo>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Section {
+    pub title: String,
+    pub pages: Vec<PageInfo>,
+}
+
+/// Initialise Tera from the configured templates directory, falling back to embedded defaults.
+pub fn init_tera(config: &BookConfig) -> Result<Tera> {
+    let mut tera = Tera::default();
+
+    let template_files = [
+        ("page", "page.html.tera"),
+        ("index", "index.html.tera"),
+        ("sidebar", "sidebar.html.tera"),
+        ("footer", "footer.html.tera"),
+        ("header", "header.html.tera"),
+    ];
+
+    for (name, file) in template_files {
+        let template_path = format!("{}/{}", config.paths.templates, file);
+        let template_content = if Path::new(&template_path).exists() {
+            fs::read_to_string(&template_path)
+                .with_context(|| format!("Failed to read template: {template_path}"))?
+        } else {
+            match file {
+                "page.html.tera" => include_str!("../templates/page.html.tera").to_string(),
+                "index.html.tera" => include_str!("../templates/index.html.tera").to_string(),
+                "sidebar.html.tera" => include_str!("../templates/sidebar.html.tera").to_string(),
+                "footer.html.tera" => include_str!("../templates/footer.html.tera").to_string(),
+                "header.html.tera" => include_str!("../templates/header.html.tera").to_string(),
+                _ => return Err(anyhow::anyhow!("Unknown template file: {}", file)),
+            }
+        };
+
+        tera.add_raw_template(name, &template_content)
+            .with_context(|| format!("Failed to add template: {name}"))?;
+    }
+
+    Ok(tera)
+}
+
+/// Extract the first H1 title from markdown, if any.
+pub fn extract_title(markdown: &str) -> Option<String> {
+    markdown
+        .lines()
+        .find(|line| line.starts_with("# "))
+        .map(|line| line[2..].trim().to_string())
+}
+
+/// Write a single chapter HTML page.
+#[allow(clippy::too_many_arguments)]
+pub fn render_page(
+    tera: &Tera,
+    html_path: &str,
+    title: String,
+    content: String,
+    sections: &[Section],
+    previous: Option<PageInfo>,
+    next: Option<PageInfo>,
+    year: &str,
+    config: &BookConfig,
+    current_path: &str,
+    watch_enabled: bool,
+) -> Result<()> {
+    let page_data = PageData {
+        title,
+        content,
+        sections: sections.to_vec(),
+        previous,
+        next,
+    };
+
+    let mut context = TeraContext::new();
+    context.insert("year", &year);
+    context.insert("page", &page_data);
+    context.insert("config", &config);
+    context.insert("current_path", &current_path);
+    context.insert("watch_enabled", &watch_enabled);
+
+    let rendered = tera
+        .render("page", &context)
+        .with_context(|| format!("Failed to render page: {}", html_path))?;
+    fs::write(html_path, rendered)
+        .with_context(|| format!("Failed to write file: {}", html_path))?;
+    Ok(())
+}
+
+/// Write `index.html` for the book.
+pub fn render_index(
+    tera: &Tera,
+    output_dir: &str,
+    index_page: Option<&PageInfo>,
+    index_content: Option<String>,
+    sections: &[Section],
+    year: &str,
+    config: &BookConfig,
+) -> Result<()> {
+    let mut context = TeraContext::new();
+    context.insert("year", &year);
+    context.insert("config", &config);
+    context.insert("sections", &sections);
+    context.insert("current_path", &"index.html");
+
+    if let (Some(index), Some(html_content)) = (index_page, index_content) {
+        context.insert("has_index", &true);
+        context.insert("title", &index.title);
+        context.insert("content", &html_content);
+    } else {
+        context.insert("has_index", &false);
+        context.insert("title", &"Documentation");
+    }
+
+    let rendered = tera
+        .render("index", &context)
+        .context("Failed to render index page")?;
+    fs::write(format!("{}/index.html", output_dir), rendered)
+        .context("Failed to write index.html")?;
+    Ok(())
+}
+
+/// Emit syntect theme CSS into the output directory.
+#[cfg(feature = "syntax-highlighting")]
+pub fn write_syntax_css(output_dir: &str) -> Result<()> {
+    use syntect::highlighting::ThemeSet;
+    use syntect::html::ClassStyle;
+
+    let ts = ThemeSet::load_defaults();
+    // TODO: Make this configurable (increment E)
+    let theme = &ts.themes["Solarized (light)"];
+    let syntax_css = syntect::html::css_for_theme_with_class_style(theme, ClassStyle::Spaced)
+        .map_err(|e| anyhow::anyhow!("CSS generation error: {:?}", e))?;
+
+    fs::write(format!("{}/css/syntax.css", output_dir), syntax_css)?;
+    Ok(())
+}
+
+#[cfg(not(feature = "syntax-highlighting"))]
+pub fn write_syntax_css(_output_dir: &str) -> Result<()> {
+    Ok(())
+}
+
+/// Copy static assets (CSS, JS, images, web components) into the output directory.
+pub fn copy_static_assets(
+    output_dir: &str,
+    templates_dir: &str,
+    _config: &BookConfig,
+) -> Result<()> {
+    fs::create_dir_all(format!("{}/css", output_dir))?;
+    fs::create_dir_all(format!("{}/js", output_dir))?;
+    fs::create_dir_all(format!("{}/img", output_dir))?;
+    fs::create_dir_all(format!("{}/components", output_dir))?;
+
+    // Copy CSS directory
+    let css_source = format!("{}/css", templates_dir);
+    let css_dest = format!("{}/css/", output_dir);
+    if Path::new(&css_source).exists() {
+        for entry in WalkDir::new(&css_source) {
+            let entry = entry?;
+            let dest_path = css_dest.clone()
+                + entry
+                    .path()
+                    .strip_prefix(&css_source)?
+                    .to_str()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Invalid UTF-8 in CSS path: {:?}", entry.path())
+                    })?;
+            if entry.file_type().is_file() {
+                fs::copy(entry.path(), dest_path)?;
+            }
+        }
+    }
+
+    // Copy JS directory
+    let js_source = format!("{}/js", templates_dir);
+    let js_dest = format!("{}/js/", output_dir);
+    fs::create_dir_all(&js_dest)?;
+    if Path::new(&js_source).exists() {
+        for entry in WalkDir::new(&js_source) {
+            let entry = entry?;
+            let dest_path = js_dest.clone()
+                + entry
+                    .path()
+                    .strip_prefix(&js_source)?
+                    .to_str()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Invalid UTF-8 in JS path: {:?}", entry.path())
+                    })?;
+            if entry.file_type().is_file() {
+                fs::copy(entry.path(), dest_path)?;
+            }
+        }
+    }
+
+    // Copy img directory from templates
+    let img_source = format!("{}/img", templates_dir);
+    let img_dest = format!("{}/img/", output_dir);
+    fs::create_dir_all(&img_dest)?;
+    if Path::new(&img_source).exists() {
+        for entry in WalkDir::new(&img_source) {
+            let entry = entry?;
+            let dest_path = img_dest.clone()
+                + entry
+                    .path()
+                    .strip_prefix(&img_source)?
+                    .to_str()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Invalid UTF-8 in image path: {:?}", entry.path())
+                    })?;
+            if entry.file_type().is_file() {
+                fs::copy(entry.path(), dest_path)
+                    .context(format!("Failed to copy img file: {:?}", entry.path()))?;
+            }
+        }
+    }
+
+    fs::write(
+        format!("{}/components/doc-toc.js", output_dir),
+        include_str!("../templates/components/doc-toc.js"),
+    )
+    .context("Failed to write TOC component")?;
+
+    fs::write(
+        format!("{}/components/simple-block.js", output_dir),
+        include_str!("../templates/components/simple-block.js"),
+    )
+    .context("Failed to write Simple Block component")?;
+
+    fs::write(
+        format!("{}/components/search-modal.js", output_dir),
+        include_str!("../templates/components/search-modal.js"),
+    )
+    .context("Failed to write Search Modal component")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::BookConfig;
+    use tempfile::TempDir;
+
+    fn project_root() -> std::path::PathBuf {
+        std::path::PathBuf::from(
+            std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
+        )
+    }
+
+    #[test]
+    fn test_extract_title_h1() {
+        let markdown = "# Main Title\n\nSome content here.";
+        let title = extract_title(markdown);
+        assert_eq!(title, Some("Main Title".to_string()));
+    }
+
+    #[test]
+    fn test_extract_title_h2() {
+        let markdown = "Some text\n\n## Section Title\n\nContent";
+        let title = extract_title(markdown);
+        assert_eq!(title, None);
+    }
+
+    #[test]
+    fn test_extract_title_no_heading() {
+        let markdown = "Just some regular text without headings.";
+        let title = extract_title(markdown);
+        assert_eq!(title, None);
+    }
+
+    #[test]
+    fn test_extract_title_complex_markup() {
+        let markdown = "# Title with **bold** and *italic*";
+        let title = extract_title(markdown);
+        assert_eq!(title, Some("Title with **bold** and *italic*".to_string()));
+    }
+
+    #[test]
+    fn test_extract_title_first_heading_wins() {
+        let markdown = "# First Title\n\n## Second Title\n\n# Third Title";
+        let title = extract_title(markdown);
+        assert_eq!(title, Some("First Title".to_string()));
+    }
+
+    #[test]
+    fn test_page_data_serialization() -> Result<()> {
+        let page_data = PageData {
+            title: "Test Page".to_string(),
+            content: "<h1>Test</h1>".to_string(),
+            sections: vec![Section {
+                title: "Section 1".to_string(),
+                pages: vec![PageInfo {
+                    title: "Page 1".to_string(),
+                    path: "/page1".to_string(),
+                }],
+            }],
+            previous: Some(PageInfo {
+                title: "Previous".to_string(),
+                path: "/prev".to_string(),
+            }),
+            next: None,
+        };
+
+        let serialized = serde_json::to_string(&page_data)?;
+        assert!(serialized.contains("Test Page"));
+        assert!(serialized.contains("Section 1"));
+        assert!(serialized.contains("/page1"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_static_assets() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let output_dir = temp_dir.path().join("output");
+        let templates_dir = project_root().join("src/templates");
+
+        fs::create_dir_all(&output_dir)?;
+
+        let config = BookConfig::default();
+        copy_static_assets(
+            output_dir.to_str().unwrap(),
+            templates_dir.to_str().unwrap(),
+            &config,
+        )?;
+
+        assert!(output_dir.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_static_assets_nonexistent_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        let templates_dir = "nonexistent_templates";
+
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let config = BookConfig::default();
+        let result = copy_static_assets(output_dir.to_str().unwrap(), templates_dir, &config);
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -1,0 +1,430 @@
+//! Markdown → HTML fragment rendering (mdast splice + optional syntect).
+
+use anyhow::Result;
+use markdown::mdast::Node;
+use markdown::to_html_with_options;
+use markdown::to_mdast;
+
+use crate::config::{BookConfig, MarkdownFormat};
+
+#[cfg(feature = "syntax-highlighting")]
+use syntect::html::{ClassStyle, ClassedHTMLGenerator};
+#[cfg(feature = "syntax-highlighting")]
+use syntect::parsing::SyntaxSet;
+#[cfg(feature = "syntax-highlighting")]
+use syntect::util::LinesWithEndings;
+
+/// Render markdown content to an HTML fragment, then rewrite internal `.md` links to `.html`.
+///
+/// When the `syntax-highlighting` feature is enabled, `syntax_set` must be `Some`.
+pub fn render_markdown(
+    content: &str,
+    config: &BookConfig,
+    #[cfg(feature = "syntax-highlighting")] syntax_set: Option<&SyntaxSet>,
+    #[cfg(not(feature = "syntax-highlighting"))] _syntax_set: Option<&()>,
+) -> Result<String> {
+    #[cfg(feature = "syntax-highlighting")]
+    {
+        let ss = syntax_set.ok_or_else(|| {
+            anyhow::anyhow!("syntax_set required when syntax-highlighting feature is enabled")
+        })?;
+        Ok(convert_md_links_to_html(
+            &process_markdown_with_highlighting(content, ss, config)?,
+        ))
+    }
+    #[cfg(not(feature = "syntax-highlighting"))]
+    {
+        Ok(convert_md_links_to_html(&process_markdown_basic(
+            content, config,
+        )?))
+    }
+}
+
+/// Converts internal .md links to .html links in HTML content.
+/// External links (http://, https://, mailto:, etc.) are not modified.
+pub fn convert_md_links_to_html(html: &str) -> String {
+    let mut result = html.to_string();
+
+    // Convert href="...md" to href="...html" (double quotes)
+    let mut start = 0;
+    while let Some(href_pos) = result[start..].find("href=\"") {
+        let abs_pos = start + href_pos;
+        let url_start = abs_pos + 6;
+
+        if let Some(quote_end) = result[url_start..].find('"') {
+            let url_end = url_start + quote_end;
+            let url = &result[url_start..url_end];
+
+            if url.ends_with(".md")
+                && !url.starts_with("http://")
+                && !url.starts_with("https://")
+                && !url.starts_with("mailto:")
+                && !url.starts_with("//")
+            {
+                let new_url = format!("{}.html", &url[..url.len() - 3]);
+                result = format!(
+                    "{}href=\"{}\"{}",
+                    &result[..abs_pos],
+                    new_url,
+                    &result[url_end + 1..]
+                );
+                start = abs_pos + 6 + new_url.len() + 1;
+            } else {
+                start = url_end + 1;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Also handle single quotes
+    start = 0;
+    while let Some(href_pos) = result[start..].find("href='") {
+        let abs_pos = start + href_pos;
+        let url_start = abs_pos + 6;
+
+        if let Some(quote_end) = result[url_start..].find('\'') {
+            let url_end = url_start + quote_end;
+            let url = &result[url_start..url_end];
+
+            if url.ends_with(".md")
+                && !url.starts_with("http://")
+                && !url.starts_with("https://")
+                && !url.starts_with("mailto:")
+                && !url.starts_with("//")
+            {
+                let new_url = format!("{}.html", &url[..url.len() - 3]);
+                result = format!(
+                    "{}href='{}'{}",
+                    &result[..abs_pos],
+                    new_url,
+                    &result[url_end + 1..]
+                );
+                start = abs_pos + 6 + new_url.len() + 1;
+            } else {
+                start = url_end + 1;
+            }
+        } else {
+            break;
+        }
+    }
+
+    result
+}
+
+fn markdown_options(config: &BookConfig) -> markdown::Options {
+    let parse_options = match config.markdown.format {
+        MarkdownFormat::Mdx => markdown::ParseOptions::mdx(),
+        MarkdownFormat::Gfm => markdown::ParseOptions::gfm(),
+        MarkdownFormat::Markdown => markdown::ParseOptions::default(),
+    };
+
+    let compile_options = if matches!(config.markdown.format, MarkdownFormat::Gfm) {
+        markdown::CompileOptions::gfm()
+    } else {
+        markdown::CompileOptions::default()
+    };
+
+    let mut options = markdown::Options {
+        parse: parse_options,
+        compile: compile_options,
+    };
+
+    options.parse.constructs.frontmatter = config.markdown.frontmatter;
+    options.parse.constructs.html_flow = config.output.html.allow_html;
+    options.parse.constructs.html_text = config.output.html.allow_html;
+    options.compile.allow_dangerous_html = config.output.html.allow_html;
+    options.compile.allow_dangerous_protocol = config.output.html.allow_html;
+
+    options
+}
+
+#[cfg(feature = "syntax-highlighting")]
+fn process_code_block(code: &str, language: Option<&str>, ss: &SyntaxSet) -> Result<String> {
+    let syntax = match language {
+        Some("rust") => {
+            let syntax = ss
+                .find_syntax_by_extension("rs")
+                .ok_or_else(|| anyhow::anyhow!("Rust syntax not found"))?;
+            if code.contains("<--editable-->") {
+                let code_with_comment = format!("{}\n// <--editable-->", code);
+                process_rust_code(&code_with_comment, syntax, ss)?
+            } else {
+                process_rust_code(code, syntax, ss)?
+            }
+        }
+        Some("mermaid") => {
+            format!(
+                "<pre class=\"code\"><code class=\"language-mermaid\">{}</code></pre>",
+                html_escape::encode_text(code)
+            )
+        }
+        Some(lang) => {
+            let syntax = ss
+                .find_syntax_by_extension(lang)
+                .or_else(|| ss.find_syntax_by_name(lang))
+                .or_else(|| ss.find_syntax_by_token(lang))
+                .or_else(|| Some(ss.find_syntax_plain_text()))
+                .ok_or_else(|| anyhow::anyhow!("Syntax not found for language: {:?}", lang))?;
+            process_generic_code(code, syntax, ss)?
+        }
+        None => {
+            let syntax = ss.find_syntax_plain_text();
+            process_generic_code(code, syntax, ss)?
+        }
+    };
+    Ok(syntax)
+}
+
+#[cfg(feature = "syntax-highlighting")]
+fn process_rust_code(
+    code: &str,
+    syntax: &syntect::parsing::SyntaxReference,
+    ss: &SyntaxSet,
+) -> Result<String> {
+    let mut html_generator =
+        ClassedHTMLGenerator::new_with_class_style(syntax, ss, ClassStyle::Spaced);
+
+    for line in LinesWithEndings::from(code) {
+        html_generator
+            .parse_html_for_line_which_includes_newline(line)
+            .map_err(|e| anyhow::anyhow!("HTML generation error: {:?}", e))?;
+    }
+    let html = html_generator.finalize();
+    Ok(format!(
+        "<pre class=\"code rust\"><code>{}</code></pre>",
+        html
+    ))
+}
+
+#[cfg(feature = "syntax-highlighting")]
+fn process_generic_code(
+    code: &str,
+    syntax: &syntect::parsing::SyntaxReference,
+    ss: &SyntaxSet,
+) -> Result<String> {
+    let mut html_generator =
+        ClassedHTMLGenerator::new_with_class_style(syntax, ss, ClassStyle::Spaced);
+
+    for line in LinesWithEndings::from(code) {
+        html_generator
+            .parse_html_for_line_which_includes_newline(line)
+            .map_err(|e| anyhow::anyhow!("HTML generation error: {:?}", e))?;
+    }
+    let html = html_generator.finalize();
+    Ok(format!("<pre class=\"code\"><code>{}</code></pre>", html))
+}
+
+#[cfg(feature = "syntax-highlighting")]
+fn process_markdown_with_highlighting(
+    content: &str,
+    ss: &SyntaxSet,
+    config: &BookConfig,
+) -> Result<String> {
+    let options = markdown_options(config);
+
+    let ast = to_mdast(content, &options.parse)
+        .map_err(|e| anyhow::anyhow!("Markdown parsing error: {:?}", e))?;
+
+    let mut parts = Vec::new();
+    let mut last_pos = 0;
+
+    fn process_node(
+        node: &Node,
+        ss: &SyntaxSet,
+        content: &str,
+        parts: &mut Vec<String>,
+        last_pos: &mut usize,
+        config: &BookConfig,
+    ) -> Result<()> {
+        match node {
+            Node::Code(code) => {
+                if let Some(pos) = &code.position {
+                    if *last_pos < pos.start.offset {
+                        let text = &content[*last_pos..pos.start.offset];
+                        if !text.trim().is_empty() {
+                            let options = markdown_options(config);
+                            let temp_html = to_html_with_options(text, &options).map_err(|e| {
+                                anyhow::anyhow!("Markdown conversion error: {:?}", e)
+                            })?;
+                            parts.push(temp_html);
+                        }
+                    }
+
+                    let highlighted = process_code_block(&code.value, code.lang.as_deref(), ss)?;
+                    parts.push(highlighted);
+
+                    *last_pos = pos.end.offset;
+                }
+            }
+            _ => {
+                if let Some(children) = node.children() {
+                    for child in children {
+                        process_node(child, ss, content, parts, last_pos, config)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    process_node(&ast, ss, content, &mut parts, &mut last_pos, config)?;
+
+    if last_pos < content.len() {
+        let remaining = &content[last_pos..];
+        if !remaining.trim().is_empty() {
+            let options = markdown_options(config);
+            parts.push(
+                to_html_with_options(remaining, &options)
+                    .map_err(|e| anyhow::anyhow!("Markdown conversion error: {:?}", e))?,
+            );
+        }
+    }
+
+    Ok(parts.join(""))
+}
+
+#[cfg(not(feature = "syntax-highlighting"))]
+fn process_markdown_basic(content: &str, config: &BookConfig) -> Result<String> {
+    let options = markdown_options(config);
+    to_html_with_options(content, &options)
+        .map_err(|e| anyhow::anyhow!("Markdown conversion error: {:?}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_md_links_to_html() {
+        let html = r#"<a href="page.md">Link</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(result, r#"<a href="page.html">Link</a>"#);
+
+        let html = r#"<a href="dir/subdir/page.md">Link</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(result, r#"<a href="dir/subdir/page.html">Link</a>"#);
+
+        let html = r#"<a href="page1.md">Link1</a> and <a href="page2.md">Link2</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(
+            result,
+            r#"<a href="page1.html">Link1</a> and <a href="page2.html">Link2</a>"#
+        );
+
+        let html = r#"<a href="https://example.com/page.md">External</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(
+            result,
+            r#"<a href="https://example.com/page.md">External</a>"#
+        );
+
+        let html = r#"<a href="http://example.com/page.md">External</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(
+            result,
+            r#"<a href="http://example.com/page.md">External</a>"#
+        );
+
+        let html = r#"<a href="page.html">Link</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(result, r#"<a href="page.html">Link</a>"#);
+
+        let html = r#"<a href="local.md">Local</a> and <a href="https://ext.com/file.md">Ext</a>"#;
+        let result = convert_md_links_to_html(html);
+        assert_eq!(
+            result,
+            r#"<a href="local.html">Local</a> and <a href="https://ext.com/file.md">Ext</a>"#
+        );
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_default() -> Result<()> {
+        let config = BookConfig::default();
+        let markdown = "# Hello World\n\nThis is **bold** text.";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(html.contains("<h1>Hello World</h1>"));
+        assert!(html.contains("<strong>bold</strong>"));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_gfm() -> Result<()> {
+        let mut config = BookConfig::default();
+        config.markdown.format = MarkdownFormat::Gfm;
+        let markdown = "# GFM Test\n\n~~strikethrough~~\n\n- [ ] Task item";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(html.contains("<h1>GFM Test</h1>"));
+        assert!(html.contains("strikethrough"));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_mdx() -> Result<()> {
+        let mut config = BookConfig::default();
+        config.markdown.format = MarkdownFormat::Mdx;
+        let markdown = "# MDX Test\n\nThis is **bold** text.";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(html.contains("<h1>MDX Test</h1>"));
+        assert!(html.contains("<strong>bold</strong>"));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_with_html_allowed() -> Result<()> {
+        let mut config = BookConfig::default();
+        config.output.html.allow_html = true;
+        let markdown = "# Test\n\n<div>Raw HTML</div>";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(html.contains("<div>Raw HTML</div>"));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_with_html_disallowed() -> Result<()> {
+        let config = BookConfig::default();
+        let markdown = "# Test\n\n<div>Raw HTML</div>";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(!html.contains("<div>Raw HTML</div>"));
+        Ok(())
+    }
+
+    #[cfg(not(feature = "syntax-highlighting"))]
+    #[test]
+    fn test_process_markdown_basic_with_frontmatter() -> Result<()> {
+        let mut config = BookConfig::default();
+        config.markdown.frontmatter = true;
+        let markdown = "---\ntitle: Test\n---\n\n# Hello World";
+        let html = process_markdown_basic(markdown, &config)?;
+        assert!(html.contains("<h1>Hello World</h1>"));
+        assert!(!html.contains("---"));
+        Ok(())
+    }
+
+    #[cfg(feature = "syntax-highlighting")]
+    #[test]
+    fn test_process_code_block_rust() -> Result<()> {
+        let ss = SyntaxSet::load_defaults_newlines();
+        let code = "fn main() {\n    println!(\"Hello, world!\");\n}";
+        let highlighted = process_code_block(code, Some("rust"), &ss)?;
+        assert!(highlighted.contains("<pre"));
+        assert!(!highlighted.is_empty());
+        Ok(())
+    }
+
+    #[cfg(feature = "syntax-highlighting")]
+    #[test]
+    fn test_process_code_block_no_language() -> Result<()> {
+        let ss = SyntaxSet::load_defaults_newlines();
+        let code = "some plain text code";
+        let highlighted = process_code_block(code, None, &ss)?;
+        assert!(highlighted.contains("<pre"));
+        assert!(highlighted.contains("some plain text code"));
+        Ok(())
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,7 @@
+//! Rendering stages: markdown → HTML fragment, then HTML page assembly.
+
+pub mod html;
+pub mod markdown;
+
+pub use html::{copy_static_assets, extract_title, init_tera, render_index, render_page, Section};
+pub use markdown::{convert_md_links_to_html, render_markdown};


### PR DESCRIPTION
## Summary

Increment **A** of mdBook feature parity (`docs/plans/mdbook-parity-implementation-plan.md`).

Pure refactor with **zero behaviour change**: the monolithic `build_sync_impl_sync` is split into named pipeline stages so B–E each target one stage.

### Changes
- `src/pipeline/` — collect → preprocess → render sequencing; async index
- `src/pipeline/preprocess.rs` — identity seam for future P2 directives
- `src/render/markdown.rs` — mdast + syntect + `.md`→`.html` link rewrite
- `src/render/html.rs` — Tera init, page/index writers, static assets
- `src/core.rs` — Args + build() orchestration only

### Gate evidence
- make qa / clippy `-D warnings` green
- Unit + integration + mdbook compatibility tests pass
- SHA-256 byte-identical to pre-A baseline: **72/72** match
- Wall-clock baseline for `test_book_mdbook`: **0.86 s** (debug; Pagefind CLI absent)

### Docs
- `docs/verification/verification-report-mdbook-parity-a.md`
- `docs/validation/validation-report-mdbook-parity-a.md`
- `docs/plans/review-mdbook-parity-a.md`

### Out of scope
- SUMMARY.md model (B), CLI subcommands (C), path_to_root/Shoelace (D), themes (E)
- Unrelated local WIP remains in git stash (not in this PR)

Refs #1
