### PR TITLE
fix: restore the index layout broken by the V-001 navigation fix

### DIFF
--- a/docs/plans/mdbook-parity-validation-report.md
+++ b/docs/plans/mdbook-parity-validation-report.md
@@ -57,7 +57,8 @@ fixed. Measuring also removed one avoidable cost (a duplicate mdast parse per pa
 
 | ID | Description | Origin | Severity | Resolution |
 |----|-------------|--------|----------|------------|
-| V-001 | Index page had no navigation: one link (the logo) versus 30 on a chapter page. A README-backed index skips the card grid, and the template never included the sidebar | **Phase 2 (design omission)** | High | `3704b0d` |
+| V-001 | Index page had no navigation: one link (the logo) versus 30 on a chapter page. A README-backed index skips the card grid | **Phase 2 (design omission)** | High | `3704b0d`, corrected in `fix/index-layout-regression` |
+| V-005 | The V-001 fix injected the chapter `.sidebar` into `.index-container`, which is `display: block !important; max-width: 1400px`. With `grid-area` meaningless outside a grid, the sidebar became a `height: 100vh; overflow-y: auto` block inside the capped-width landing page — a fixed-width column with its own scrollbar. Reported by the user, not by any test | **Phase 3 (my fix ignored the target layout)** | High | Card grid now renders alongside index content; no sidebar on the landing page |
 | V-002 | Sidebar's deprecated branch read `page.sections`, absent from the index context — an empty book failed to render | Phase 2 (context asymmetry) | Medium | `3704b0d` |
 | V-003 | Logo link had no accessible name (`alt=""` on the image left the anchor unnamed) | Phase 3 | **Serious (WCAG 2.4.4, 4.1.2)** | `8bcc6b7` |
 | V-004 | On-this-page component emitted bare `div`s, leaving content outside any landmark | Phase 2 (component markup unspecified) | Moderate | `8bcc6b7` |

--- a/src/templates/index.html.tera
+++ b/src/templates/index.html.tera
@@ -35,22 +35,23 @@
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <div class="container index-container">
         {% include "header.html" %}
-        {# The landing page needs the same navigation as any chapter: with a
-           README-backed index the card grid is skipped, which used to leave the
-           page with no way to reach the book at all. #}
-        <div class="sidebar">
-            {% include "sidebar.html" %}
-        </div>
         <main class="content index-content" id="main-content">
             {% if has_index %}
                 <article class="main-article">
                     {{ content | safe }}
                 </article>
-            {% else %}
+            {% endif %}
+            {% if not has_index %}
                 <div class="index-header">
                     <h1>Documentation</h1>
                 </div>
-                <div class="card-grid">
+            {% endif %}
+            {# The card grid is this page's navigation, and the reason the
+               layout is a full-width block rather than the chapter grid. It
+               used to render only when there was no index page of its own,
+               which left a README-backed book with no route into its
+               chapters at all. #}
+            <div class="card-grid">
                     {% for section in sections %}
                         <div class="section-group">
                             <h2>{{ section.title }}</h2>
@@ -58,7 +59,7 @@
                                 {% for page in section.pages %}
                                     <sl-card class="doc-card">
                                         <h3 slot="header">{{ page.title }}</h3>
-                                        <sl-button href="{{ path_to_root | safe }}{{ page.path }}" variant="default">
+                                        <sl-button href="{{ path_to_root | safe }}{{ page.path | safe }}" variant="default">
                                             Read More
                                             <sl-icon slot="suffix" name="arrow-right"></sl-icon>
                                         </sl-button>
@@ -67,8 +68,7 @@
                             </div>
                         </div>
                     {% endfor %}
-                </div>
-            {% endif %}
+            </div>
         </main>
     </div>
     

--- a/tests/integration/build_test.rs
+++ b/tests/integration/build_test.rs
@@ -1323,7 +1323,11 @@ async fn test_index_page_is_navigable() -> Result<()> {
     let index = book.read_output("index.html")?;
     assert_contains!(index, "one.html");
     assert_contains!(index, "sub/two.html");
-    assert_contains!(index, "sidebar-nav");
+    // Navigation here is the card grid, not the chapter sidebar: the landing
+    // page is a full-width block layout by design, and dropping a grid-area
+    // sidebar into it produced a fixed-width column with its own scrollbar.
+    assert_contains!(index, "card-grid");
+    assert_not_contains!(index, "class=\"sidebar\"");
 
     Ok(())
 }


### PR DESCRIPTION
Reported by the user: the index page became fixed-width with its own scrollbar, breaking the wide-monitor layout.

## Cause — mine

`.index-container` is `display: block !important; max-width: 1400px`: deliberately a full-width, centred landing page with **no** sidebar. My V-001 fix dropped the chapter `.sidebar` into it. `grid-area: sidebar` means nothing outside a grid, so it rendered as a `height: 100vh; overflow-y: auto` block inside the capped container — a fixed-width column with a scrollbar.

The problem V-001 identified was real (a README-backed index reached no chapter), but the fix ignored the layout it was editing. No test caught it because every test asserted link presence, never layout.

## Fix

The card grid is the landing page's navigation, and the reason the layout is a full-width block. It rendered only when the book had no index page of its own; it now renders in both cases, so README content and the routes into the book appear together.

Card links also get `| safe` — they are escaped at construction, and Tera was escaping them again into `individual&#x2F;index.html`.

## Not touched

The multi-column article flow (`column-width: 40ch; column-gap: 4rem; column-rule`) is byte-identical to the pre-branch stylesheet. That wide-monitor design is intact.

## Verified at 1280px

| | |
|---|---|
| container display | `block` |
| `.sidebar` elements | 0 |
| horizontal scrollbar | none |
| card links | 30 |
| README content | present |

Full suite green; the test that asserted the wrong fix now asserts the card grid and the absence of a sidebar.